### PR TITLE
synapses trainable, set_states, get_params

### DIFF
--- a/neurax/channels/channel.py
+++ b/neurax/channels/channel.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Tuple
 
-# from neurax.modules.base import View
 import jax.numpy as jnp
 
 

--- a/neurax/modules/branch.py
+++ b/neurax/modules/branch.py
@@ -92,7 +92,7 @@ class Branch(Module):
 
 class BranchView(View):
     def __init__(self, pointer, view):
-        view["controlled_by_param"] = view["branch_index"]
+        view.assign(controlled_by_param=view.branch_index)
         super().__init__(pointer, view)
 
     def __call__(self, index: float):

--- a/neurax/modules/cell.py
+++ b/neurax/modules/cell.py
@@ -175,7 +175,7 @@ class CellView(View):
     """CellView."""
 
     def __init__(self, pointer, view):
-        view["controlled_by_param"] = view["cell_index"]
+        view.assign(controlled_by_param=view.cell_index)
         super().__init__(pointer, view)
 
     def __call__(self, index: float):

--- a/neurax/modules/compartment.py
+++ b/neurax/modules/compartment.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict, List, Optional
 import jax.numpy as jnp
 import pandas as pd
 
-from neurax.channels import Channel  # , ChannelView
+from neurax.channels import Channel
 from neurax.modules.base import Module, View
 from neurax.utils.cell_utils import index_of_loc
 
@@ -71,7 +71,7 @@ class CompartmentView(View):
     """CompartmentView."""
 
     def __init__(self, pointer, view):
-        view["controlled_by_param"] = view["comp_index"]
+        view.assign(controlled_by_param=view.comp_index)
         super().__init__(pointer, view)
 
     def __call__(self, loc: float):

--- a/tutorials/01_small_network.ipynb
+++ b/tutorials/01_small_network.ipynb
@@ -2,7 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
+   "id": "e38051a5-e754-4dc7-9e1c-caa42e340fa3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "99a23786",
    "metadata": {},
    "outputs": [],
@@ -18,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "7490f08b",
    "metadata": {},
    "outputs": [],
@@ -45,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 4,
    "id": "200ce0b1",
    "metadata": {},
    "outputs": [],
@@ -65,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 5,
    "id": "72ef3df2",
    "metadata": {},
    "outputs": [],
@@ -83,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 6,
    "id": "9eb9bddf-dc93-420a-a4a9-7b1c9ba296a1",
    "metadata": {},
    "outputs": [],
@@ -112,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 7,
    "id": "b91f3280",
    "metadata": {},
    "outputs": [],
@@ -124,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 8,
    "id": "094aeb79",
    "metadata": {},
    "outputs": [],
@@ -144,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 9,
    "id": "d3616f0e-ebf0-46b1-bdca-3b67e8c222b4",
    "metadata": {},
    "outputs": [],
@@ -154,16 +165,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 22,
    "id": "7b55f750",
    "metadata": {},
    "outputs": [],
    "source": [
     "conn_builder = nx.ConnectivityBuilder([cell.total_nbranches for _ in range(num_cells)])\n",
     "\n",
+    "_ = np.random.seed(0)  # location of post synapse is random.\n",
     "connectivities = [\n",
     "    nx.Connectivity(\n",
-    "        GlutamateSynapse,\n",
+    "        GlutamateSynapse(),\n",
     "        [\n",
     "            *conn_builder.fc(np.arange(0, 5), np.arange(5, 15)),\n",
     "            *conn_builder.fc(np.arange(5, 15), np.arange(15, 16)),\n",
@@ -174,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 23,
    "id": "d8ea160b",
    "metadata": {},
    "outputs": [],
@@ -219,7 +231,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "s = nx.integrate(network, stimuli=stims, recordings=recs, delta_t=dt, params=[])"
+    "s = nx.integrate(network, stimuli=stims, recordings=recs, delta_t=dt)"
    ]
   },
   {
@@ -253,13 +265,8 @@
     "fig, ax = plt.subplots(1, 1, figsize=(6.3, 3))\n",
     "for i in range(len(recs)):\n",
     "    _ = ax.plot(time_vec, s[i][:-1], c=\"k\")\n",
-    "ax.set_xlabel(\"\")\n",
-    "ax.set_xticks([])\n",
-    "ax.set_xticks(np.arange(0, max(time_vec)+1, 10))\n",
-    "ax.set_xlim([0, max(time_vec)])\n",
     "ax.set_xlabel(\"Time (ms)\")\n",
     "ax.set_ylabel(\"Voltage (mV)\")\n",
-    "plt.subplots_adjust(hspace=0.4)\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
Internally, this splits `self.params` and `self.syn_params`. This allows to run `network.make_trainable("gS")` and knowing that the indices that should be kept track of are the indices of the edges, not the nodes.