### PR TITLE
New indexing

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -34,7 +34,23 @@ class Module(ABC):
         self.group_views = {}
 
         self.nodes: Optional[pd.DataFrame] = None
-        self.syn_edges: Optional[pd.DataFrame] = None
+
+        self.syn_edges = pd.DataFrame(
+            columns=[
+                "pre_locs",
+                "post_locs",
+                "pre_branch_index",
+                "post_branch_index",
+                "pre_cell_index",
+                "post_cell_index",
+                "type",
+                "type_ind",
+                "global_pre_comp_index",
+                "global_post_comp_index",
+                "global_pre_branch_index",
+                "global_post_branch_index",
+            ]
+        )
         self.branch_edges: Optional[pd.DataFrame] = None
 
         self.cumsum_nbranches: Optional[jnp.ndarray] = None
@@ -865,9 +881,6 @@ class View:
             self.view = self.view[self.view[key].isin(index)]
         else:
             assert index == "all"
-        self.view["comp_index"] -= self.view["comp_index"].iloc[0]
-        self.view["branch_index"] -= self.view["branch_index"].iloc[0]
-        self.view["cell_index"] -= self.view["cell_index"].iloc[0]
         self.view["controlled_by_param"] -= self.view["controlled_by_param"].iloc[0]
         return self
 

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -137,7 +137,9 @@ class BranchView(View):
 
     def __call__(self, index: float):
         self.allow_make_trainable = True
-        return super().adjust_view("branch_index", index)
+        new_view = super().adjust_view("branch_index", index)
+        new_view.view["comp_index"] -= new_view.view["comp_index"].iloc[0]
+        return new_view
 
     def __getattr__(self, key):
         assert key == "comp"

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -250,7 +250,10 @@ class CellView(View):
     def __call__(self, index: float):
         if index == "all":
             self.allow_make_trainable = False
-        return super().adjust_view("cell_index", index)
+        new_view = super().adjust_view("cell_index", index)
+        new_view.view["comp_index"] -= new_view.view["comp_index"].iloc[0]
+        new_view.view["branch_index"] -= new_view.view["branch_index"].iloc[0]
+        return new_view
 
     def __getattr__(self, key):
         assert key == "branch"


### PR DESCRIPTION
This changes the `view`:
```python
net2.cell(1).branch(4).comp(0.2).view
```

Would have previously yielded `[0, 0, 0]` for `[comp_index, branch_index, cell_index]`. It now yields `[1, 4, 2]`.