### PR TITLE
Channel name prefix to params and states

### DIFF
--- a/jaxley/channels/channel.py
+++ b/jaxley/channels/channel.py
@@ -6,26 +6,26 @@ from jax import vmap
 
 
 class Channel:
-    _channel_name = None
+    _name = None
     channel_params = None
     channel_states = None
 
-    def __init__(self, channel_name: Optional[str] = None):
-        self._channel_name = channel_name if channel_name else self.__class__.__name__
+    def __init__(self, name: Optional[str] = None):
+        self._name = name if name else self.__class__.__name__
         self.vmaped_update_states = vmap(self.update_states, in_axes=(0, None, 0, 0))
         self.vmapped_compute_current = vmap(
             self.compute_current, in_axes=(None, 0, None)
         )
 
     @property
-    def channel_name(self) -> Optional[str]:
-        return self._channel_name
+    def name(self) -> Optional[str]:
+        return self._name
 
     def change_name(self, new_name: str):
-        old_prefix = self._channel_name + "_"
+        old_prefix = self._name + "_"
         new_prefix = new_name + "_"
 
-        self._channel_name = new_name
+        self._name = new_name
         self.channel_params = {
             (
                 new_prefix + key[len(old_prefix) :]

--- a/jaxley/channels/hh.py
+++ b/jaxley/channels/hh.py
@@ -9,9 +9,9 @@ from jaxley.solver_gate import solve_gate_exponential
 class HH(Channel):
     """Hodgkin-Huxley channel."""
 
-    def __init__(self, channel_name: Optional[str] = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: Optional[str] = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gNa": 0.12,
             f"{prefix}_gK": 0.036,
@@ -30,7 +30,7 @@ class HH(Channel):
         self, u: Dict[str, jnp.ndarray], dt, voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return updated HH channel state."""
-        prefix = self._channel_name
+        prefix = self._name
         ms, hs, ns = u[f"{prefix}_m"], u[f"{prefix}_h"], u[f"{prefix}_n"]
         new_m = solve_gate_exponential(ms, dt, *_m_gate(voltages))
         new_h = solve_gate_exponential(hs, dt, *_h_gate(voltages))
@@ -41,7 +41,7 @@ class HH(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current through HH channels."""
-        prefix = self._channel_name
+        prefix = self._name
         ms, hs, ns = u[f"{prefix}_m"], u[f"{prefix}_h"], u[f"{prefix}_n"]
 
         # Multiply with 1000 to convert Siemens to milli Siemens.

--- a/jaxley/channels/pospischil.py
+++ b/jaxley/channels/pospischil.py
@@ -27,9 +27,9 @@ def efun(x):
 class Leak(Channel):
     """Leak current"""
 
-    def __init__(self, channel_name: Optional[str] = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: Optional[str] = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gl": 1e-4,
             f"{prefix}_el": -70.0,
@@ -46,7 +46,7 @@ class Leak(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current."""
-        prefix = self._channel_name
+        prefix = self._name
         # Multiply with 1000 to convert Siemens to milli Siemens.
         leak_conds = params[f"{prefix}_gl"] * 1000  # mS/cm^2
         return leak_conds * (voltages - params[f"{prefix}_el"])
@@ -55,9 +55,9 @@ class Leak(Channel):
 class Na(Channel):
     """Sodium channel"""
 
-    def __init__(self, channel_name: str | None = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: str | None = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gNa": 50e-3,
             f"{prefix}_eNa": 50.0,
@@ -69,7 +69,7 @@ class Na(Channel):
         self, u: Dict[str, jnp.ndarray], dt, voltages, params: Dict[str, jnp.ndarray]
     ):
         """Update state."""
-        prefix = self._channel_name
+        prefix = self._name
         ms, hs = u[f"{prefix}_m"], u[f"{prefix}_h"]
         new_m = solve_gate_exponential(ms, dt, *_m_gate(voltages, params["vt"]))
         new_h = solve_gate_exponential(hs, dt, *_h_gate(voltages, params["vt"]))
@@ -79,7 +79,7 @@ class Na(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current."""
-        prefix = self._channel_name
+        prefix = self._name
         ms, hs = u[f"{prefix}_m"], u[f"{prefix}_h"]
 
         # Multiply with 1000 to convert Siemens to milli Siemens.
@@ -110,9 +110,9 @@ def _h_gate(v, vt):
 class K(Channel):
     """Potassium channel"""
 
-    def __init__(self, channel_name: Optional[str] = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: Optional[str] = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gK": 5e-3,
             f"{prefix}_eK": -90.0,
@@ -124,7 +124,7 @@ class K(Channel):
         self, u: Dict[str, jnp.ndarray], dt, voltages, params: Dict[str, jnp.ndarray]
     ):
         """Update state."""
-        prefix = self._channel_name
+        prefix = self._name
         ns = u[f"{prefix}_n"]
         new_n = solve_gate_exponential(ns, dt, *_n_gate(voltages, params["vt"]))
         return {f"{prefix}_n": new_n}
@@ -133,7 +133,7 @@ class K(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current."""
-        prefix = self._channel_name
+        prefix = self._name
         ns = u[f"{prefix}_n"]
 
         # Multiply with 1000 to convert Siemens to milli Siemens.
@@ -154,9 +154,9 @@ def _n_gate(v, vt):
 class Km(Channel):
     """Slow M Potassium channel"""
 
-    def __init__(self, channel_name: str | None = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: str | None = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gM": 0.004e-3,
             f"{prefix}_taumax": 4000.0,
@@ -168,7 +168,7 @@ class Km(Channel):
         self, u: Dict[str, jnp.ndarray], dt, voltages, params: Dict[str, jnp.ndarray]
     ):
         """Update state."""
-        prefix = self._channel_name
+        prefix = self._name
         ps = u[f"{prefix}_p"]
         new_p = solve_inf_gate_exponential(
             ps, dt, *_p_gate(voltages, params[f"{prefix}_taumax"])
@@ -179,7 +179,7 @@ class Km(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current."""
-        prefix = self._channel_name
+        prefix = self._name
         ps = u[f"{prefix}_p"]
 
         # Multiply with 1000 to convert Siemens to milli Siemens.
@@ -199,9 +199,9 @@ def _p_gate(v, taumax):
 class NaK(Channel):
     """Sodium and Potassium channel"""
 
-    def __init__(self, channel_name: Optional[str] = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: Optional[str] = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gNa": 0.05,
             f"{prefix}_eNa": 50.0,
@@ -220,7 +220,7 @@ class NaK(Channel):
     ):
         """Update state."""
 
-        prefix = self._channel_name
+        prefix = self._name
         ms, hs, ns = u[f"{prefix}_m"], u[f"{prefix}_h"], u[f"{prefix}_n"]
         new_m = solve_gate_exponential(ms, dt, *_m_gate(voltages, params["vt"]))
         new_h = solve_gate_exponential(hs, dt, *_h_gate(voltages, params["vt"]))
@@ -231,7 +231,7 @@ class NaK(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current."""
-        prefix = self._channel_name
+        prefix = self._name
         ms, hs, ns = u[f"{prefix}_m"], u[f"{prefix}_h"], u[f"{prefix}_n"]
 
         # Multiply with 1000 to convert Siemens to milli Siemens.
@@ -246,9 +246,9 @@ class NaK(Channel):
 class CaL(Channel):
     """L-type Calcium channel"""
 
-    def __init__(self, channel_name: Optional[str] = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: Optional[str] = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gCaL": 0.1e-3,
             "eCa": 120.0,
@@ -259,7 +259,7 @@ class CaL(Channel):
         self, u: Dict[str, jnp.ndarray], dt, voltages, params: Dict[str, jnp.ndarray]
     ):
         """Update state."""
-        prefix = self._channel_name
+        prefix = self._name
         qs, rs = u[f"{prefix}_q"], u[f"{prefix}_r"]
         new_q = solve_gate_exponential(qs, dt, *_q_gate(voltages))
         new_r = solve_gate_exponential(rs, dt, *_r_gate(voltages))
@@ -269,7 +269,7 @@ class CaL(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current."""
-        prefix = self._channel_name
+        prefix = self._name
         qs, rs = u[f"{prefix}_q"], u[f"{prefix}_r"]
 
         # Multiply with 1000 to convert Siemens to milli Siemens.
@@ -299,9 +299,9 @@ def _r_gate(v):
 class CaT(Channel):
     """T-type Calcium channel"""
 
-    def __init__(self, channel_name: Optional[str] = None):
-        super().__init__(channel_name)
-        prefix = self._channel_name
+    def __init__(self, name: Optional[str] = None):
+        super().__init__(name)
+        prefix = self._name
         self.channel_params = {
             f"{prefix}_gCaT": 0.4e-4,
             f"{prefix}_vx": 2.0,
@@ -313,7 +313,7 @@ class CaT(Channel):
         self, u: Dict[str, jnp.ndarray], dt, voltages, params: Dict[str, jnp.ndarray]
     ):
         """Update state."""
-        prefix = self._channel_name
+        prefix = self._name
         us = u[f"{prefix}_u"]
         new_u = solve_inf_gate_exponential(
             us, dt, *_u_gate(voltages, params[f"{prefix}_vx"])
@@ -324,7 +324,7 @@ class CaT(Channel):
         self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
     ):
         """Return current."""
-        prefix = self._channel_name
+        prefix = self._name
         us = u[f"{prefix}_u"]
         s_inf = 1.0 / (1.0 + jnp.exp(-(voltages + params[f"{prefix}_vx"] + 57.0) / 6.2))
 

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -11,11 +11,11 @@ from jaxley.channels import K, Na
 
 def test_channel_set_name():
     # default name is the class name
-    assert Na().channel_name == "Na"
+    assert Na().name == "Na"
 
     # channel name can be set in the constructor
-    na = Na(channel_name="NaPospischil")
-    assert na.channel_name == "NaPospischil"
+    na = Na(name="NaPospischil")
+    assert na.name == "NaPospischil"
     assert "NaPospischil_gNa" in na.channel_params.keys()
     assert "NaPospischil_eNa" in na.channel_params.keys()
     assert "NaPospischil_h" in na.channel_states.keys()
@@ -26,7 +26,7 @@ def test_channel_set_name():
     # channel name can not be changed directly
     k = K()
     with pytest.raises(AttributeError):
-        k.channel_name = "KPospischil"
+        k.name = "KPospischil"
     assert "KPospischil_gNa" not in k.channel_params.keys()
     assert "KPospischil_eNa" not in k.channel_params.keys()
     assert "KPospischil_h" not in k.channel_states.keys()
@@ -38,7 +38,7 @@ def test_channel_change_name():
     # channel name can be changed with change_name method
     # (and only this way after initialization)
     na.change_name("NaPospischil")
-    assert na.channel_name == "NaPospischil"
+    assert na.name == "NaPospischil"
     assert "NaPospischil_gNa" in na.channel_params.keys()
     assert "NaPospischil_eNa" in na.channel_params.keys()
     assert "NaPospischil_h" in na.channel_states.keys()


### PR DESCRIPTION
### Main Changes

- Added `channel_name` as a property to the `Channel` class, ensuring it can only be altered using the `change_name` method (which will automatically change all prefixes in `channel_states` and `channel_params`).
- Removed the `staticmethod` decorator from `update_states` and `compute_current`, so that they can access `channel_name`.
- Updated all existing channels in `hh.py` and `pospischil.py` to accommodate this change.

### Example

```python
na = Na()
print(na.channel_name, na.channel_params)

na = Na(channel_name="Na2")
print(na.channel_name, na.channel_params)

na.change_name("Na3")
print(na.channel_name, na.channel_params)
```

result:

```
Na {'Na_gNa': 0.05, 'Na_eNa': 50.0, 'vt': -60.0}
Na2 {'Na2_gNa': 0.05, 'Na2_eNa': 50.0, 'vt': -60.0}
Na3 {'Na3_gNa': 0.05, 'Na3_eNa': 50.0, 'vt': -60.0}
```