### PR TITLE
Allow renamed channels in simulation

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -104,9 +104,7 @@ class Module(ABC):
         """
         for module in constituents:
             for channel in module.channels:
-                if channel._name not in [
-                    c._name for c in self.channels
-                ]:
+                if channel._name not in [c._name for c in self.channels]:
                     self.channels.append(channel)
         # Setting columns of channel names to `False` instead of `NaN`.
         for channel in self.channels:


### PR DESCRIPTION
Previously, we used `type(channel).__name__` to determine if a channel already exists in the network.

However, if we rename a channel, we want to consider the channel a new (different) channel with its own parameter names etc. Therefore, we now use `channel._name` to determine if a channel already exists.

The difference is easily visible when doing:
```python
renamed_hh = HH()
renamed_hh.change_name("NeuronHH")

comp = jx.Compartment()
branch = jx.Branch(comp, nseg=4)

branch.comp(0.0).insert(HH())
branch.insert(renamed_hh)
```

And then inspecting `branch.nodes["HH"]`. Before this commit, this returned:
```python
0    True
1    True
2    True
3    True
Name: HH, dtype: bool
```

Now, it returns:
```python
0    False
1    False
2    False
3     True
Name: HH, dtype: bool
```

@huangziwei FYI