### PR TITLE
TypeOptimizer

### DIFF
--- a/jaxley/optimize/__init__.py
+++ b/jaxley/optimize/__init__.py
@@ -1,1 +1,2 @@
+from jaxley.optimize.optimizer import TypeOptimizer
 from jaxley.optimize.transforms import ParamTransform

--- a/jaxley/optimize/optimizer.py
+++ b/jaxley/optimize/optimizer.py
@@ -1,12 +1,28 @@
 from typing import Dict, List, Optional
 
 import jax.numpy as jnp
-import optax
 
 
-class ParameterTypeOptimizer:
+class TypeOptimizer:
     """Wrapper for `optax` optimizer which allows different lrs for different params."""
-    def __init__(self, optimizer: optax.optimizer, lrs: Dict, opt_params: List[Dict[str, jnp.ndarray]]):
+
+    def __init__(
+        self,
+        optimizer,
+        lrs: Dict,
+        opt_params: List[Dict[str, jnp.ndarray]],
+    ) -> None:
+        """Create the optimizers.
+
+        This requires access to `opt_params` in order to know how many optimizers
+        should be created. It creates `len(opt_params)` optimizers.
+
+        Args:
+            optimizer: The `optax.optimizer` (not instantiated) which should be used.
+            lrs: The learning rates to be used for different kinds of parameters.
+            opt_params: The parameters to be optimizer. The exact values are not used,
+                only the number of elements in the list and the key of each dict.
+        """
         self.base_optimizer = optimizer
 
         self.optimizers = []
@@ -16,19 +32,23 @@ class ParameterTypeOptimizer:
             name = names[0]
             optimizer = self.base_optimizer(learning_rate=lrs[name])
             self.optimizers.append({name: optimizer})
-        
+
     def init(self, opt_params: List[Dict[str, jnp.ndarray]]):
+        """Initialize the optimizers. Equivalent to `optax.optimizers.init()`."""
         opt_states = []
         for params, optimizer in zip(opt_params, self.optimizers):
-            opt_state = optimizer.init(params)
+            name = list(optimizer.keys())[0]
+            opt_state = optimizer[name].init(params)
             opt_states.append(opt_state)
         return opt_states
 
-    def update(self, gradient, opt_states):
+    def update(self, gradient, opt_state):
+        """Update the optimizers. Equivalent to `optax.optimizers.update()`."""
         all_updates = []
         new_opt_states = []
-        for grad, state, opt in zip(gradient, opt_states, self.optimizers):
-            updates, new_opt_states = opt.update(grad, state)
+        for grad, state, opt in zip(gradient, opt_state, self.optimizers):
+            name = list(opt.keys())[0]
+            updates, new_opt_state = opt[name].update(grad, state)
             all_updates.append(updates)
-            new_opt_states.append(new_opt_states)
-        return updates, new_opt_states
+            new_opt_states.append(new_opt_state)
+        return all_updates, new_opt_states

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,77 @@
+import jax
+
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_platform_name", "cpu")
+
+import jax.numpy as jnp
+import numpy as np
+import optax
+from jax import jit, value_and_grad
+
+import jaxley as jx
+from jaxley.channels import HH
+from jaxley.optimize import TypeOptimizer
+
+
+def test_type_optimizer():
+    """Tests whether optimization recovers a ground truth parameter set."""
+    comp = jx.Compartment()
+    comp.insert(HH())
+    comp.record()
+    comp.stimulate(jx.step_current(0.1, 3.0, 0.1, 0.025, 5.0))
+
+    comp.set("HH_gNa", 0.4)
+    comp.set("radius", 30.0)
+
+    def simulate(params):
+        return jx.integrate(comp, params=params)
+
+    observation = simulate([{}])
+    comp.set("HH_gNa", 0.3)
+    comp.make_trainable("HH_gNa")
+
+    comp.set("radius", 20.0)
+    comp.make_trainable("radius")
+
+    def loss_fn(params):
+        res = simulate(params)
+        return jnp.mean((observation - res) ** 2)
+
+    grad_fn = jit(value_and_grad(loss_fn))
+
+    # Diverse lr -> good learning.
+    opt_params = comp.get_parameters()
+    lrs = {"HH_gNa": 0.01, "radius": 1.0}
+    optimizer = TypeOptimizer(optax.adam, lrs, opt_params)
+    opt_state = optimizer.init(opt_params)
+
+    for i in range(500):
+        l, grad = grad_fn(opt_params)
+        updates, opt_state = optimizer.update(grad, opt_state)
+        opt_params = optax.apply_updates(opt_params, updates)
+    assert l < 1e-5, "Loss should be low if a diverse lr is used."
+
+    # Too low lr -> poor learning.
+    opt_params = comp.get_parameters()
+    optimizer = optax.adam(0.01)
+    opt_state = optimizer.init(opt_params)
+
+    for i in range(500):
+        l, grad = grad_fn(opt_params)
+        updates, opt_state = optimizer.update(grad, opt_state)
+        opt_params = optax.apply_updates(opt_params, updates)
+
+    assert l > 3.0, "Loss should be high if a uniformly low lr is used."
+
+    # Too high lr -> poor learning.
+    opt_params = comp.get_parameters()
+    optimizer = optax.adam(1.0)
+    opt_state = optimizer.init(opt_params)
+
+    # Run two epochs to ensure everything also works after a full run-through.
+    for i in range(500):
+        l, grad = grad_fn(opt_params)
+        updates, opt_state = optimizer.update(grad, opt_state)
+        opt_params = optax.apply_updates(opt_params, updates)
+
+    assert l > 30.0, "Loss should be high if a uniformly high lr is used."


### PR DESCRIPTION
The `TypeOptimizer` allows to use different learning rates for different types of parameters. For example, it allows to use a learning rate of `0.01` for sodium conductances and `1.0` for radiuses.

```python
comp = jx.Compartment()
comp.insert(HH())
comp.record()
comp.make_trainable("HH_gNa")
comp.make_trainable("radius")

opt_params = comp.get_parameters()
lrs = {"HH_gNa": 0.01, "radius": 1.0}
optimizer = TypeOptimizer(optax.adam, lrs, opt_params)
opt_state = optimizer.init(opt_params)

def loss_fn(params):
    return jnp.mean(jx.integrate(comp, params=params))

grad_fn = jit(value_and_grad(loss_fn))
loss, grad = grad_fn(opt_params)
updates, opt_state = optimizer.update(grad, opt_state)
opt_params = optax.apply_updates(opt_params, updates)
```

@kyralianaka @jnsbck FYI