### PR TITLE
Change indexing to equally sized segments

### DIFF
--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -153,19 +153,17 @@ def index_of_loc(branch_ind: int, loc: float, nseg_per_branch: int) -> int:
     Returns:
         The index of the compartment within the entire cell.
     """
-    if nseg_per_branch > 1:
-        possible_locs = np.arange(nseg_per_branch) / (nseg_per_branch - 1)
-        closest = np.argmin(np.abs(possible_locs - loc))
-        ind_along_branch = nseg_per_branch - closest - 1
-    else:
-        ind_along_branch = 0
-    return branch_ind * nseg_per_branch + ind_along_branch
+    nseg = nseg_per_branch  # only for convenience.
+    possible_locs = np.linspace(0.5 / nseg, 1 - 0.5 / nseg, nseg)
+    closest = np.argmin(np.abs(possible_locs - loc))
+    ind_along_branch = nseg - closest - 1
+    return branch_ind * nseg + ind_along_branch
 
 
 def loc_of_index(global_comp_index, nseg):
     """Return location corresponding to index."""
     index = global_comp_index % nseg
-    possible_locs = np.linspace(1, 0, nseg)
+    possible_locs = np.linspace(1 - 0.5 / nseg, 0.5 / nseg, nseg)
     return possible_locs[index]
 
 

--- a/tests/neurax_identical/test_basic_modules.py
+++ b/tests/neurax_identical/test_basic_modules.py
@@ -221,24 +221,24 @@ def test_complex_net():
 
     voltages = jx.integrate(net)
 
-    voltages_040224 = jnp.asarray(
+    voltages_170224 = jnp.asarray(
         [
             [
                 -70.0,
-                -63.40803312,
-                -59.4254583,
-                -54.78764382,
-                -31.76834458,
-                6.05115398,
-                -45.91493618,
-                -74.97970891,
-                -74.04696989,
-                -72.53339424,
-                -70.76922395,
+                -63.40805687,
+                -59.42555966,
+                -54.78818167,
+                -31.81369416,
+                6.08431881,
+                -45.88646897,
+                -74.97831595,
+                -74.04577549,
+                -72.53153729,
+                -70.76670823,
             ]
         ]
     )
 
-    max_error = np.max(np.abs(voltages[:, ::40] - voltages_040224))
+    max_error = np.max(np.abs(voltages[:, ::40] - voltages_170224))
     tolerance = 1e-8
     assert max_error <= tolerance, f"Error is {max_error} > {tolerance}"

--- a/tests/neurax_identical/test_grad.py
+++ b/tests/neurax_identical/test_grad.py
@@ -60,28 +60,28 @@ def test_network_grad():
     grad_fn = value_and_grad(simulate)
     v, g = grad_fn(params)
 
-    value_040224 = jnp.asarray(-610.62777059)
-    max_error = np.max(np.abs(v - value_040224))
+    value_170224 = jnp.asarray(-610.59244206)
+    max_error = np.max(np.abs(v - value_170224))
     tolerance = 1e-8
     assert max_error <= tolerance, f"Error is {max_error} > {tolerance}"
     grad_040224 = [
-        {"HH_gNa": jnp.asarray([[-464.58880073]])},
-        {"HH_gK": jnp.asarray([[1.99849062], [0.22679202], [10.19699616]])},
+        {"HH_gNa": jnp.asarray([[-471.60465337]])},
+        {"HH_gK": jnp.asarray([[1.55258077], [0.16785627], [8.87050663]])},
         {
             "HH_gLeak": jnp.asarray(
                 [
-                    [-7.90344616e01],
-                    [-7.55178874e00],
-                    [-8.67132533e01],
-                    [-4.97164503e02],
-                    [-9.72827298e02],
-                    [-1.60479444e02],
-                    [-1.05619123e05],
+                    [-6.59547510e01],
+                    [-7.20277308e00],
+                    [-8.01210580e01],
+                    [-5.23790208e02],
+                    [-8.77460674e02],
+                    [-1.62911998e02],
+                    [-1.07148436e05],
                 ]
             )
         },
-        {"gS": jnp.asarray([[-43.45642964]])},
-        {"gC": jnp.asarray([[-0.03109039], [-0.01530678]])},
+        {"gS": jnp.asarray([[-43.87992857]])},
+        {"gC": jnp.asarray([[-0.03726582], [-0.01559716]])},
     ]
 
     for true_g, new_g in zip(grad_040224, g):


### PR DESCRIPTION
Previously, the segment locations had been `np.linspace(0, 1, nseg)`. 

Now, they are `np.linspace(nseg/2, 1-nseg/2, nseg)`. This leads to equally sized segments.

Closes #195 