### PR TITLE
change: channel naming conventions

### DIFF
--- a/jaxley/channels/channel.py
+++ b/jaxley/channels/channel.py
@@ -48,13 +48,13 @@ class Channel:
         }
 
     def update_states(
-        self, u, dt, voltages, params
+        self, states, dt, v, params
     ) -> Tuple[jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray]]:
         """Return the updated states."""
         pass
 
     def compute_current(
-        self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
+        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
     ):
         """Given channel states and voltage, return the current through the channel."""
         pass

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -108,34 +108,34 @@ def test_multiple_channel_currents():
         channel_params = {}
         channel_states = {"cumulative": 0.0}
 
-        def update_states(self, u, dt, voltages, params):
-            state = u["cumulative"]
-            state += u["Dummy1_current"] * 0.001
-            state += u["Dummy2_current"] * 0.001
+        def update_states(self, states, dt, v, params):
+            state = states["cumulative"]
+            state += states["Dummy1_current"] * 0.001
+            state += states["Dummy2_current"] * 0.001
             return {"cumulative": state}
 
-        def compute_current(self, u, voltages, params):
-            return 0.01 * jnp.ones_like(voltages)
+        def compute_current(self, states, v, params):
+            return 0.01 * jnp.ones_like(v)
 
     class Dummy1(Channel):
         channel_params = {}
         channel_states = {}
 
-        def update_states(self, u, dt, voltages, params):
+        def update_states(self, states, dt, v, params):
             return {}
 
-        def compute_current(self, u, voltages, params):
-            return 0.01 * jnp.ones_like(voltages)
+        def compute_current(self, states, v, params):
+            return 0.01 * jnp.ones_like(v)
 
     class Dummy2(Channel):
         channel_params = {}
         channel_states = {}
 
-        def update_states(self, u, dt, voltages, params):
+        def update_states(self, states, dt, v, params):
             return {}
 
-        def compute_current(self, u, voltages, params):
-            return 0.01 * jnp.ones_like(voltages)
+        def compute_current(self, states, v, params):
+            return 0.01 * jnp.ones_like(v)
 
     dt = 0.025  # ms
     t_max = 10.0  # ms


### PR DESCRIPTION
1. plural `voltages` > singular `v`;
2. short hand `u` > `states` explicitly;
3. `{channel}_cond` > `g{channel}`
4. `ms`, `ns`, `hs`, etc. > `m`, `n`, `h`, etc.


