### PR TITLE
`layers` is now supported for networks of detailed neurons

### DIFF
--- a/tests/test_plotting_api.py
+++ b/tests/test_plotting_api.py
@@ -60,6 +60,9 @@ def test_network():
     net.vis(detail="point", layers=[2, 1])
 
     # Plot 5.
+    net.vis(detail="full", layers=[2, 1])
+
+    # Plot 5.
     net.cell(0).add_to_group("excitatory")
     net.cell(1).add_to_group("excitatory")
     ax = net.excitatory.vis()


### PR DESCRIPTION
```python
import matplotlib.pyplot as plt
import jaxley as jx
from jaxley.synapses import GlutamateSynapse


comp = jx.Compartment()
branch = jx.Branch(comp, nseg=4)
cell = jx.Cell(branch, parents=[-1, 0, 0, 1, 1])
net = jx.Network([cell for _ in range(8)])

pre = net.cell([0, 1, 2, 3])
post = net.cell([4, 5, 6])
pre.fully_connect(post, GlutamateSynapse())

pre = net.cell([4, 5, 6])
post = net.cell(7)
pre.fully_connect(post, GlutamateSynapse())

net.compute_xyz()

fig, ax = plt.subplots(1, 1, figsize=(5, 5))
ax = net.vis(
    ax=ax, 
    detail="full", 
    layers=[3, 4, 1], 
    layer_kwargs={
        "vertical_layers": False, 
        "within_layer_offset": 100.0, 
        "between_layer_offset": 200.0
    }
)
plt.show()
```