### PR TITLE
add xyz attrs  to `module.nodes`

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -17,23 +17,10 @@ from jaxley.utils.cell_utils import (
     _compute_index_of_child,
     _compute_num_children,
     compute_levels,
-    # interpolate_xyz,
+    interpolate_xyz,
     loc_of_index,
 )
 from jaxley.utils.plot_utils import plot_morph
-
-
-def interpolate_xyz(loc: float, coords: np.ndarray):
-    """Perform a linear interpolation between xyz-coordinates.
-    Args:
-        loc: The location in [0,1] along the branch.
-        coords: Array containing the reconstructed xyzr points of the branch.
-    Return:
-        Interpolated xyz coordinate at `loc`, shape `(3,).
-    """
-    return vmap(lambda x: jnp.interp(loc, jnp.linspace(0, 1, len(x)), x), in_axes=(1,))(
-        coords[:, :3]
-    )
 
 
 class Module(ABC):


### PR DESCRIPTION
This PR adds ability to include xyz coords in `module.nodes`. Can handle both manually created and imported morphologies.

I added the function: `module.update_nodes_with_xyz()` which adds xyz coordinates to `module.nodes`. Could in theory be called after every call to `compute_xyz()`. We could do this by default or leave it to the user. What is your opinion?

If the number of coords in module.xyzr != nsegs coordinates are linearly interpolated between the endpoints. This should also yield the correct compartment lengths.

Lemme know if this needs tests or changes.