### PR TITLE
Bugfix: compute z in compute_xyz()

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -867,7 +867,7 @@ class Module(ABC):
                         ((index_of_child[b] / (num_children_of_parent - 1))) - 0.5
                     ) * y_offset_multiplier[levels[b]]
                 else:
-                    start_point = [0, 0]
+                    start_point = [0, 0, 0]
                     y_offset = 0.0
 
                 len_of_path = np.sqrt(y_offset**2 + 1.0)
@@ -875,10 +875,11 @@ class Module(ABC):
                 end_point = [
                     start_point[0] + branch_lens[b] / len_of_path * 1.0,
                     start_point[1] + branch_lens[b] / len_of_path * y_offset,
+                    start_point[2],
                 ]
                 endpoints.append(end_point)
 
-                self.xyzr[b][:, :2] = np.asarray([start_point, end_point])
+                self.xyzr[b][:, :3] = np.asarray([start_point, end_point])
             else:
                 # Dummy to keey the index `endpoints[parent[b]]` above working.
                 endpoints.append(np.zeros((2,)))


### PR DESCRIPTION
Before, running compute_xyz() would return a 2x4 array such as `array[[0,0, nan, nan], [10, 0, nan, nan]]` if the cell location wasn't specified in its creation. Then, if one wanted to move the cell, one could only change the x & y coordinates, because adding anything to the z coordinate would just return `nan`.

I simply changed this so that `compute_xyz` gives the cell a default z coordinate of zero, and its z coordinate can then be changed with `move()`. 
