### PR TITLE
make `.change_name()` chainable

### DIFF
--- a/jaxley/channels/channel.py
+++ b/jaxley/channels/channel.py
@@ -24,6 +24,9 @@ class Channel:
 
         Args:
             new_name: The new name of the channel.
+
+        Returns:
+            Renamed channel, such that this function is chainable.
         """
         old_prefix = self._name + "_"
         new_prefix = new_name + "_"
@@ -46,6 +49,7 @@ class Channel:
             ): value
             for key, value in self.channel_states.items()
         }
+        return self
 
     def update_states(
         self, states, dt, v, params

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -36,10 +36,9 @@ def test_channel_set_name():
 
 
 def test_channel_change_name():
-    na = Na()
     # channel name can be changed with change_name method
     # (and only this way after initialization)
-    na.change_name("NaPospischil")
+    na = Na().change_name("NaPospischil")
     assert na.name == "NaPospischil"
     assert "NaPospischil_gNa" in na.channel_params.keys()
     assert "NaPospischil_eNa" in na.channel_params.keys()
@@ -50,8 +49,7 @@ def test_channel_change_name():
 
 
 def test_integration_with_renamed_channels():
-    neuron_hh = HH()
-    neuron_hh.change_name("NeuronHH")
+    neuron_hh = HH().change_name("NeuronHH")
     standard_hh = HH()
 
     comp = jx.Compartment()


### PR DESCRIPTION
Previously, one needed three lines to insert a renamed channel:
```python
channel = HH()
channel.change_name("HH_renamed")
cell.insert(channel)
```

I now made the `change_name()` function chainable such that this reduces to one line:
```python
cell.insert(HH().change_name("HH_renamed"))
```

@huangziwei FYI