### PR TITLE
Local indices computation minor bugfix

### DIFF
--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -236,7 +236,7 @@ class CellView(View):
         local_idcs = self._get_local_indices()
         self.view[local_idcs.columns] = (
             local_idcs  # set indexes locally. enables net[0:2,0:2]
-        ) 
+        )
         if index == "all":
             self.allow_make_trainable = False
         new_view = super().adjust_view("cell_index", index)


### PR DESCRIPTION
Removed invalid argument `include_groups` from the `_get_local_indices` method that was causing the main branch to fail most of the tests.