### PR TITLE
Bugfix if current through channel is used as a state

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -748,7 +748,7 @@ class Module(ABC):
                 channel_states[s] = states[s][indices]
 
             for current_name in self.membrane_current_names:
-                channel_states[current_name] = states[current_name]
+                channel_states[current_name] = states[current_name][indices]
 
             states_updated = channel.update_states(
                 channel_states, delta_t, voltages[indices], channel_params

--- a/tests/test_shared_state.py
+++ b/tests/test_shared_state.py
@@ -7,6 +7,7 @@ jax.config.update("jax_platform_name", "cpu")
 
 import jax.numpy as jnp
 import numpy as np
+from jaxley_mech.channels.l5pc import CaHVA, CaPump
 
 import jaxley as jx
 from jaxley.channels import HH, Channel, K, Na
@@ -77,3 +78,15 @@ def test_shared_state():
         comp.stimulate(current)
 
         voltages.append(jx.integrate(comp))
+
+
+def test_current_as_state_multicompartment():
+    """#323 had discovered a bug when currents are only used in a few compartments."""
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 2)
+
+    branch.comp(0).insert(CaHVA())  # defines current `i_Ca`
+    branch.comp(0).insert(CaPump())  # uses `states["i_Ca"]`
+
+    branch.comp(0).record()
+    _ = jx.integrate(branch, t_max=1.0)


### PR DESCRIPTION
As with `params` and all `states`, only those compartments which actually have a certain channel should be taken the `current_states` from.

Tests are passing.

Minimal example to reproduce, also added to tests:

```python
comp = jx.Compartment()
branch = jx.Branch(comp, 2)

branch.comp(0).insert(CaHVA())  # defines current `i_Ca`
branch.comp(0).insert(CaPump())  # uses `states["i_Ca"]`

branch.comp(0).record()
_ = jx.integrate(branch, t_max=1.0)
```