### PR TITLE
Allow subclassing groups

### DIFF
--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -78,7 +78,7 @@ class Branch(Module):
             view["global_comp_index"] = view["comp_index"]
             view["global_branch_index"] = view["branch_index"]
             view["global_cell_index"] = view["cell_index"]
-            return GroupView(self, view)
+            return GroupView(self, view, CompartmentView, ["comp", "loc"])
         else:
             raise KeyError(f"Key {key} not recognized.")
 

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -111,7 +111,7 @@ class Cell(Module):
             view["global_comp_index"] = view["comp_index"]
             view["global_branch_index"] = view["branch_index"]
             view["global_cell_index"] = view["cell_index"]
-            return GroupView(self, view)
+            return GroupView(self, view, BranchView, ["branch"])
         else:
             raise KeyError(f"Key {key} not recognized.")
 

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -107,7 +107,7 @@ class Network(Module):
             view["global_comp_index"] = view["comp_index"]
             view["global_branch_index"] = view["branch_index"]
             view["global_cell_index"] = view["cell_index"]
-            return GroupView(self, view)
+            return GroupView(self, view, CellView, ["cell"])
         else:
             raise KeyError(f"Key {key} not recognized.")
 

--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -1,5 +1,5 @@
 from math import pi
-from typing import Dict, List
+from typing import Dict, List, Optional, Union
 
 import jax.numpy as jnp
 import numpy as np
@@ -242,3 +242,23 @@ def convert_point_process_to_distributed(
     area = 2 * pi * radius * length
     current /= area  # nA / um^2
     return current * 100_000  # Convert (nA / um^2) to (uA / cm^2)
+
+
+def childview(
+    module,
+    index: Union[int, str, list, range, slice],
+    child_name: Optional[str] = None,
+):
+    """Return the child view of the current module.
+
+    network.cell(index) at network level.
+    cell.branch(index) at cell level.
+    branch.comp(index) at branch level."""
+    if child_name is None:
+        parent_name = module.__class__.__name__.lower()
+        views = np.array(["net", "cell", "branch", "comp", "/"])
+        child_idx = np.roll([v in parent_name for v in views], 1)
+        child_name = views[child_idx][0]
+    if child_name != "/":
+        return module.__getattr__(child_name)(index)
+    raise AttributeError("Compartment does not support indexing")

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,155 @@
+import jax
+import pytest
+
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_platform_name", "cpu")
+
+
+import jax.numpy as jnp
+import numpy as np
+from jax import jit, value_and_grad
+
+import jaxley as jx
+from jaxley.channels import HH
+from jaxley.connection import fully_connect
+from jaxley.synapses import IonotropicSynapse
+
+
+def test_subclassing_groups_cell_api():
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 4)
+    cell = jx.Cell(branch, [-1, 0, 0, 1, 1])
+
+    cell.branch([0, 3, 4]).add_to_group("subtree")
+
+    # The following lines are made possible by PR #324.
+    cell.subtree.branch(0).set("radius", 0.1)
+    cell.subtree.branch(0).comp("all").make_trainable("length")
+
+    with pytest.raises(KeyError):
+        cell.subtree.cell(0).branch("all").make_trainable("length")
+    with pytest.raises(KeyError):
+        cell.subtree.comp(0).make_trainable("length")
+
+
+def test_subclassing_groups_net_api():
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 4)
+    cell = jx.Cell(branch, [-1])
+    net = jx.Network([cell for _ in range(10)])
+
+    net.cell([0, 3, 5]).add_to_group("excitatory")
+
+    # The following lines are made possible by PR #324.
+    net.excitatory.cell(0).set("radius", 0.1)
+    net.excitatory.cell(0).branch("all").make_trainable("length")
+
+    with pytest.raises(KeyError):
+        cell.excitatory.branch(0).comp("all").make_trainable("length")
+    with pytest.raises(KeyError):
+        cell.excitatory.comp("all").make_trainable("length")
+
+
+def test_subclassing_groups_net_set_equivalence():
+    """Test whether calling `.set` on subclasses group is same as on view."""
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 4)
+    cell = jx.Cell(branch, [-1, 0])
+    net1 = jx.Network([cell for _ in range(10)])
+    net2 = jx.Network([cell for _ in range(10)])
+
+    net1.cell([0, 3, 5]).add_to_group("excitatory")
+
+    # The following lines are made possible by PR #324.
+    net1.excitatory.cell([0, 3]).branch(0).comp("all").set("radius", 0.14)
+    net1.excitatory.cell([0, 5]).branch(1).comp("all").set("length", 0.16)
+    net1.excitatory.cell("all").branch(1).comp(2).set("axial_resistivity", 1100.0)
+    net1.excitatory.cell("all").branch(1).loc(0.0).set("axial_resistivity", 1300.0)
+
+    net2.cell([0, 3]).branch(0).comp("all").set("radius", 0.14)
+    net2.cell([0, 5]).branch(1).comp("all").set("length", 0.16)
+    net2.cell([0, 3, 5]).branch(1).comp(2).set("axial_resistivity", 1100.0)
+    net2.cell([0, 3, 5]).branch(1).loc(0.0).set("axial_resistivity", 1300.0)
+
+    assert all(net1.nodes == net2.nodes)
+
+
+def test_subclassing_groups_net_make_trainable_equivalence():
+    """Test whether calling `.maek_trainable` on subclasses group is same as on view."""
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 4)
+    cell = jx.Cell(branch, [-1, 0])
+    net1 = jx.Network([cell for _ in range(10)])
+    net2 = jx.Network([cell for _ in range(10)])
+
+    net1.cell([0, 3, 5]).add_to_group("excitatory")
+
+    # The following lines are made possible by PR #324.
+    net1.excitatory.cell([0, 3]).branch(0).make_trainable("radius")
+    net1.excitatory.cell([0, 5]).branch(1).comp("all").make_trainable("length")
+    net1.excitatory.cell("all").branch(1).comp(2).make_trainable("axial_resistivity")
+    params1 = jnp.concatenate(jax.tree_flatten(net1.get_parameters())[0])
+
+    net2.cell([0, 3]).branch(0).make_trainable("radius")
+    net2.cell([0, 5]).branch(1).comp("all").make_trainable("length")
+    net2.cell([0, 3, 5]).branch(1).comp(2).make_trainable("axial_resistivity")
+    params2 = jnp.concatenate(jax.tree_flatten(net2.get_parameters())[0])
+    assert jnp.array_equal(params1, params2)
+
+    for inds1, inds2 in zip(
+        net1.indices_set_by_trainables, net2.indices_set_by_trainables
+    ):
+        assert jnp.array_equal(inds1, inds2)
+
+
+def test_subclassing_groups_net_lazy_indexing_make_trainable_equivalence():
+    """Test whether groups can be indexing in a lazy way."""
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 4)
+    cell = jx.Cell(branch, [-1, 0])
+    net1 = jx.Network([cell for _ in range(10)])
+    net2 = jx.Network([cell for _ in range(10)])
+
+    net1.cell([0, 3, 5]).add_to_group("excitatory")
+    net2.cell([0, 3, 5]).add_to_group("excitatory")
+
+    # The following lines are made possible by PR #324.
+    net1.excitatory.cell([0, 3]).branch(0).make_trainable("radius")
+    net1.excitatory.cell([0, 5]).branch(1).comp("all").make_trainable("length")
+    net1.excitatory.cell("all").branch(1).comp(2).make_trainable("axial_resistivity")
+    params1 = jnp.concatenate(jax.tree_flatten(net1.get_parameters())[0])
+
+    # The following lines are made possible by PR #324.
+    net2.excitatory[[0, 3], 0].make_trainable("radius")
+    net2.excitatory[[0, 5], 1, :].make_trainable("length")
+    net2.excitatory[:, 1, 2].make_trainable("axial_resistivity")
+    params2 = jnp.concatenate(jax.tree_flatten(net2.get_parameters())[0])
+
+    assert jnp.array_equal(params1, params2)
+
+    for inds1, inds2 in zip(
+        net1.indices_set_by_trainables, net2.indices_set_by_trainables
+    ):
+        assert jnp.array_equal(inds1, inds2)
+
+
+def test_fully_connect_groups_equivalence():
+    """Test whether groups can be used with `fully_connect`."""
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 4)
+    cell = jx.Cell(branch, [-1, 0])
+    net1 = jx.Network([cell for _ in range(10)])
+    net2 = jx.Network([cell for _ in range(10)])
+
+    net1.cell([0, 3, 5]).add_to_group("layer1")
+    net1.cell([6, 8]).add_to_group("layer2")
+
+    pre = net1.layer1.cell("all")
+    post = net1.layer2.cell("all")
+    fully_connect(pre, post, IonotropicSynapse())
+
+    pre = net2.cell([0, 3, 5])
+    post = net2.cell([6, 8])
+    fully_connect(pre, post, IonotropicSynapse())
+
+    assert all(net1.edges == net2.edges)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -11,7 +11,12 @@ import numpy as np
 
 import jaxley as jx
 from jaxley.channels import HH
-from jaxley.utils.cell_utils import flip_comp_indices, index_of_loc, loc_of_index
+from jaxley.utils.cell_utils import (
+    childview,
+    flip_comp_indices,
+    index_of_loc,
+    loc_of_index,
+)
 
 
 def test_flip_compartment_indices():
@@ -218,15 +223,15 @@ def test_child_view():
     cell = jx.Cell([branch for _ in range(5)], parents=jnp.asarray([-1, 0, 0, 1, 1]))
     net = jx.Network([cell for _ in range(2)])
 
-    assert np.all(net._childview(0).show() == net.cell(0).show())
-    assert np.all(cell._childview(0).show() == cell.branch(0).show())
-    assert np.all(branch._childview(0).show() == branch.comp(0).show())
+    assert np.all(childview(net, 0).show() == net.cell(0).show())
+    assert np.all(childview(cell, 0).show() == cell.branch(0).show())
+    assert np.all(childview(branch, 0).show() == branch.comp(0).show())
 
     assert np.all(
-        net._childview(0)._childview(0).show() == net.cell(0).branch(0).show()
+        childview(childview(net, 0), 0).show() == net.cell(0).branch(0).show()
     )
     assert np.all(
-        cell._childview(0)._childview(0).show() == cell.branch(0).comp(0).show()
+        childview(childview(cell, 0), 0).show() == cell.branch(0).comp(0).show()
     )
 
 


### PR DESCRIPTION
This PR implements two things:

### 1) Merging `__getitem__` and `._childview` of `View` and `Module`

Previously, `__getitem__` and `.childview` were implemented in `View` and `Module` and had very overlapping code. So I did my best to merge them. All tests pass, but please @jnsbck have a look and let me know if I missed sth or if there was a strong reason to have very similar versions of `__getitem__` and `.childview`

### 2) Subclassing `group`s
```python
comp = jx.Compartment()
branch = jx.Branch(comp, 4)
cell = jx.Cell(branch, [-1])
net = jx.Network([cell for _ in range(10)])
net.cell([0,3,5]).add_to_group("excitatory")

# Groups can now be subclassed with `.cell`:
net.excitatory.cell(0).set("radius", 0.1)
net.excitatory.cell(0).branch("all").make_trainable("length")

# It is also possible to use lazy indexing here:
net.excitatory[0,1,:].set("radius", 0.1)

# Groups can also be used with the `fully_connect` method:
pre = net.excitatory.cell("all")
post = net.cell([6,7,8])
fully_connect(pre, post, IonotropicSynapse())
```