### PR TITLE
Automatically add groups for SWC reader

### DIFF
--- a/jaxley/utils/swc.py
+++ b/jaxley/utils/swc.py
@@ -43,6 +43,10 @@ def swc_to_jaxley(
         radius_fns = [lambda x: content[0, 5] * np.ones_like(x)] + radius_fns
         sorted_branches = [[0]] + sorted_branches
 
+        # Type of padded section is assumed to be of `custom` type:
+        # http://www.neuronland.org/NLMorphologyConverter/MorphologyFormats/SWC/Spec.html
+        types = [5.0] + types
+
     all_coords_of_branches = []
     for i, branch in enumerate(sorted_branches):
         coords_of_branch = content[np.asarray(branch) - 1, 2:6]

--- a/tests/jaxley_identical/test_swc.py
+++ b/tests/jaxley_identical/test_swc.py
@@ -23,7 +23,8 @@ def test_swc_cell():
 
     dirname = os.path.dirname(__file__)
     fname = os.path.join(dirname, "../morph.swc")
-    cell = jx.read_swc(fname, nseg=2, max_branch_len=300.0)
+    cell = jx.read_swc(fname, nseg=2, max_branch_len=300.0, assign_groups=True)
+    _ = cell.soma  # Only to test whether the `soma` group was created.
     cell.insert(HH())
     cell.branch(1).loc(0.0).record()
     cell.branch(1).loc(0.0).stimulate(current)


### PR DESCRIPTION
One can now pass `assign_groups` to `read_swc`, which will automatically create `.soma`, `.basal`,... groups.

```python
cell = jx.read_swc(fname, nseg=4, assign_groups=True)
print(cell.soma)
```

