### PR TITLE
Bugfix: Allow making multiple initial states trainable

### DIFF
--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -151,7 +151,11 @@ def integrate(
             if key in list(states.keys()):  # Only initial states, not parameters.
                 if key not in module.synapse_state_names:
                     inds = flip_comp_indices(inds, module.nseg)  # See 305
-                states[key] = states[key].at[inds].set(set_param[key])
+                # `inds` is of shape `(num_params, num_comps_per_param)`.
+                # `set_param` is of shape `(num_params,)`
+                # We need to unsqueeze `set_param` to make it `(num_params, 1)` for the
+                # `.set()` to work. This is done with `[:, None]`.
+                states[key] = states[key].at[inds].set(set_param[key][:, None])
 
     # Add to the states the initial current through every channel.
     states, _ = module._channel_currents(

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -471,6 +471,10 @@ class Module(ABC):
                 inds = flip_comp_indices(parameter["indices"], self.nseg)  # See #305
             set_param = parameter["val"]
             if key in list(params.keys()):  # Only parameters, not initial states.
+                # `inds` is of shape `(num_params, num_comps_per_param)`.
+                # `set_param` is of shape `(num_params,)`
+                # We need to unsqueeze `set_param` to make it `(num_params, 1)` for the
+                # `.set()` to work. This is done with `[:, None]`.
                 params[key] = params[key].at[inds].set(set_param[:, None])
 
         # Compute conductance params and append them.

--- a/tests/test_make_trainable.py
+++ b/tests/test_make_trainable.py
@@ -398,3 +398,24 @@ def test_data_set_vs_make_trainable_network():
     voltages1 = jx.integrate(net1, params=params1)
     voltages2 = jx.integrate(net2, param_state=pstate)
     assert np.max(np.abs(voltages1 - voltages2)) < 1e-8
+
+
+def test_make_states_trainable_api():
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, 4)
+    cell = jx.Cell(branch, [-1, 0])
+    net = jx.Network([cell for _ in range(2)])
+    net.insert(HH())
+    net.cell(0).branch(0).comp(0).record()
+
+    net.cell("all").make_trainable("v")
+    net.make_trainable("HH_h")
+    net.cell(0).branch("all").make_trainable("HH_m")
+    net.cell(0).branch("all").comp("all").make_trainable("HH_n")
+
+    def simulate(params):
+        return jx.integrate(net, params=params, t_max=10.0)
+
+    parameters = net.get_parameters()
+    v = simulate(parameters)
+    assert np.invert(np.any(np.isnan(v))), "Found NaN in voltage."


### PR DESCRIPTION
### Bugfix for making states trainable

We had a bug with making **multiple** initial states trainable. The bug was introduced in #294, where we changed `parameters` returned by `make_trainable` to not have shape `(num_params, 1)` but just `(num_params)`. In #294 we then unsqueezed during `.set` [here](https://github.com/jaxleyverse/jaxley/blob/536098f44ef3f6c121dce27cf9eee59531144cbe/jaxley/modules/base.py#L473-L474) but I forgot to also unsqueeze for the states. This is now done in this PR.

@Matthijspals thanks for noticing!

closes #331