### PR TITLE
Fixup for .vis()

### DIFF
--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -112,10 +112,11 @@ class CompartmentView(View):
         dims: Tuple[int] = (0, 1),
         morph_plot_kwargs: Dict = {},
     ):
+        nodes = self.set_global_index_and_index(self.view)
         return self.pointer._scatter(
             ax=ax,
             col=col,
             dims=dims,
-            view=self.view,
+            view=nodes,
             morph_plot_kwargs=morph_plot_kwargs,
         )


### PR DESCRIPTION
To reproduce the bug:

```python
import jaxley as jx
import matplotlib.pyplot as plt


comp = jx.Compartment()
branch = jx.Branch(comp, 4)
cell = jx.Cell(branch, [-1, 0, 0])
net = jx.Network([cell for _ in range(3)])
net.cell(1).add_to_group("exc")

net.compute_xyz()
for i in range(3):
    net.cell(i).move(300 * i, 0, 0)

fig, ax = plt.subplots(1, 1, figsize=(8, 2))
ax = net.vis(ax=ax)
ax = net[1,1,1].vis(ax=ax)
plt.show()
```
![tmp](https://github.com/jaxleyverse/jaxley/assets/24639769/1f78d768-1a1b-41a0-92bc-2c3b7fd833d3)

@coschroeder I think that this might be relevant for your plotting, so please `git pull`