### PR TITLE
Allow reading SWC files that trace the soma as a single value

### DIFF
--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -269,6 +269,11 @@ def read_swc(
 ):
     """Reads SWC file into a `jx.Cell`.
 
+    Jaxley assumes cylindrical compartments and therefore defines length and radius
+    for every compartment. The surface area is then 2*pi*r*length. For branches
+    consisting of a single traced point we assume for them to have area 4*pi*r*r.
+    Therefore, in these cases, we set lenght=2*r.
+
     Args:
         fname: Path to the swc file.
         nseg: The number of compartments per branch.

--- a/tests/test_plotting_api.py
+++ b/tests/test_plotting_api.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 
 import jax
 
@@ -140,7 +141,7 @@ def test_mixed_network():
     net.cell(1).move(0, -800)
     net.rotate(180)
 
-    before_xyzrs = net.xyzr[len(cell1.xyzr) :]
+    before_xyzrs = deepcopy(net.xyzr[len(cell1.xyzr) :])
     net.cell(1).rotate(90)
     after_xyzrs = net.xyzr[len(cell1.xyzr) :]
     # Test that rotation worked as expected.


### PR DESCRIPTION
Many SWC files, e.g. those from the Allen cell types database, trace the soma as a single point. This PR adds functionality to read such SWC files.

- Fixup for the xyz coordinate of the "artificially" added branch
- Allow single point soma in SWC
- Fixup for broken test