### PR TITLE
Cleanup `_step_channels_state` see #205

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -745,7 +745,7 @@ class Module(ABC):
             channel_param_names += ["radius", "length", "axial_resistivity"]
             channel_state_names = list(channel.channel_states)
             channel_state_names += self.membrane_current_names
-            indices = flipped_indices[channel_nodes[channel._name]]
+            indices = flipped_indices[channel_nodes[channel._name].astype(bool)]
 
             channel_params = query(params, channel_param_names, indices)
             channel_states = query(states, channel_state_names, indices)


### PR DESCRIPTION
slightly cleaner code for param querying.

Worth mentioning are:
- indices are only flipped once now, instead of for every channel.
- `query` now returns subset of parameters, and is more efficient.
- code is a bit more elegant

Kept the loop over channels, since `channel.update_states`, needs to be run individually. Did not want to mess about with doing some `map` stuff.

EDIT: all tests are passing now.

Lemme know if this is different from what you had in mind when you opened #205 @michaeldeistler.