### PR TITLE
Method for getting synapse indices

### DIFF
--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -174,39 +174,6 @@ class Network(Module):
         )
         self.initialized_syns = True
 
-    def get_synapse_indices(
-        self,
-        pre_cells: Union[int, List],
-        post_cells: Union[int, List],
-        synapse_type: str,
-    ) -> List[int]:
-        """Get the synapse indices in the SynapseView between the given pre and post synaptic cells.
-
-        These synapses can then be used to index into the SynapseView of the respective
-        synapse type and set parameters.
-        """
-        # Have to convert to lists to make the dataframe for connection identification
-        pre_cells = [pre_cells] if isinstance(pre_cells, int) else pre_cells
-        post_cells = [post_cells] if isinstance(post_cells, int) else post_cells
-        edges_of_synapse_type = self.edges[self.edges["type"] == synapse_type]
-        edge_properties_df = pd.DataFrame(
-            {"pre_cell_index": pre_cells, "post_cell_index": post_cells}
-        )
-        # Exists will be "both" here for all edges between pre and post synaptic cell(s)
-        comparison_df = pd.merge(
-            edges_of_synapse_type,
-            edge_properties_df,
-            on=["pre_cell_index", "post_cell_index"],
-            how="left",
-            indicator="exists",
-        )
-        synapse_indices = comparison_df[
-            comparison_df["exists"] == "both"
-        ].index.to_numpy()
-        if synapse_indices.size == 0:
-            raise ValueError("No synapses found with the given edge properties.")
-        return list(synapse_indices)
-
     def _step_synapse(
         self,
         states,

--- a/tests/test_synapse_indexing.py
+++ b/tests/test_synapse_indexing.py
@@ -221,7 +221,15 @@ def test_get_synapse_indices():
     network = jx.Network([cell for _ in range(5)])
     fully_connect(network.cell("all"), network.cell("all"), IonotropicSynapse())
     fully_connect(network.cell("all"), network.cell("all"), TanhRateSynapse())
+
     ionotropic_inds = network.get_synapse_indices([0, 1], [2, 3], "IonotropicSynapse")
     tanh_inds = network.get_synapse_indices(0, 2, "TanhRateSynapse")
     assert np.all(np.array(ionotropic_inds) == np.array([2, 8]))
     assert tanh_inds[0] == 2
+
+    some_cells = network.cell([1, 2, 3])
+    # NOTE: indexing into the cell view with global cell indices here, see issue #338
+    ionotropic_inds = some_cells.get_synapse_indices(
+        [1, 2], [2, 3], "IonotropicSynapse"
+    )
+    assert np.all(np.array(ionotropic_inds) == np.array([7, 13]))

--- a/tests/test_synapse_indexing.py
+++ b/tests/test_synapse_indexing.py
@@ -221,19 +221,7 @@ def test_get_synapse_indices():
     network = jx.Network([cell for _ in range(5)])
     fully_connect(network.cell("all"), network.cell("all"), IonotropicSynapse())
     fully_connect(network.cell("all"), network.cell("all"), TanhRateSynapse())
-    ionotropic_inds = network.get_synapse_indices(
-        {
-            "pre_cell_index": np.array([0, 1]),
-            "post_cell_index": np.array([2, 3]),
-            "type": "IonotropicSynapse",
-        }
-    )
-    tanh_inds = network.get_synapse_indices(
-        {
-            "pre_cell_index": np.array([0, 1]),
-            "post_cell_index": np.array([2, 3]),
-            "type": "TanhRateSynapse",
-        }
-    )
+    ionotropic_inds = network.get_synapse_indices([0, 1], [2, 3], "IonotropicSynapse")
+    tanh_inds = network.get_synapse_indices(0, 2, "TanhRateSynapse")
     assert np.all(np.array(ionotropic_inds) == np.array([2, 8]))
-    assert np.all(np.array(tanh_inds) == np.array([2, 8]))
+    assert tanh_inds[0] == 2


### PR DESCRIPTION
I wrote a method in network.py for getting the indices of synapses in the SynapseView given their edge properties. I'm happy to put it somewhere else though if someone prefers. This addresses two git issues, #336 and #264, but it doesn't fully resolve #264, rather just the first step. 

I do find it a bit odd that there is not one SynapseView per network with all of the synapses, and rather that one indexes into the different synapse types separately. Especially since the parameters are even explicitly prefixed by the synapse type. I figured the full ramifications of changing to a unified synapse view would require a longer conversation though, and it doesn't seem particularly necessary, just nicer to look at. 

I am also happy to change the argument type, because I know that passing a dictionary to a method is very cumbersome. I just wanted to make it flexible as described in #264 :)