### PR TITLE
add: add clone tridiax and pytest actions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,10 +36,22 @@ jobs:
       run: |
         isort -c jaxley tests
 
-    # - name: Test with pytest
-    #   run: |
-    #     pip install pytest pytest-cov
-    #     pytest -m "not tridiax" tests/ --cov=jaxley --cov-report=xml
+    - name: clone tridiax repo
+      uses: actions/checkout@v1  
+      with:
+        owner: jaxleyverse
+        repository: tridiax
+        access-token: ${{secrets.ACCESS_TOKEN}}
+
+    - name: install tridiax
+      run: |
+        cd triadax
+        python -m pip install -e .
+    
+    - name: Test with pytest
+      run: |
+        pip install pytest pytest-cov
+        pytest -m tests/ --cov=jaxley --cov-report=xml
       
     # - name: Upload coverage to Codecov
     #   uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,10 +37,10 @@ jobs:
         isort -c jaxley tests
 
     - name: clone tridiax repo
-      uses: actions/checkout@v1  
+      uses: jaxleyverse/clone-github-repo-action@v2.3
       with:
-        owner: jaxleyverse
-        repository: tridiax
+        owner: 'jaxleyverse'
+        repository: 'tridiax'
         access-token: ${{secrets.ACCESS_TOKEN}}
 
     - name: install tridiax


### PR DESCRIPTION
We can either push `tridiax` to pypi or just install it from source. The latter would requite generating a personal access token in the org, which unfortunately I don't have permission to do. See here for how to do it. [Clone Github Repository Action](https://github.com/marketplace/actions/clone-github-repo-action).

