### PR TITLE
fix  equidistant interpolation in xyz computation

### DIFF
--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -295,8 +295,8 @@ def interpolate_xyz(loc: float, coords: np.ndarray):
         Interpolated xyz coordinate at `loc`, shape `(3,).
     """
     dl = np.sqrt(np.sum(np.diff(coords[:, :3], axis=0) ** 2, axis=1))
-    pathlens = np.insert(np.cumsum(dl), 0, 0) # cummulative length of sections
-    norm_pathlens = pathlens/pathlens[-1]  # path lengths normalized to [0,1]
+    pathlens = np.insert(np.cumsum(dl), 0, 0)  # cummulative length of sections
+    norm_pathlens = pathlens / pathlens[-1]  # path lengths normalized to [0,1]
 
     return v_interp(loc, norm_pathlens, coords[:, :3])
 


### PR DESCRIPTION
the current implementation of `compute_xyz` does not correctly compute the locations of the xyz coordinates, according to their position along the traced path to be interpolated, but just sets `xp=linspace(0,1,len(x))`.

I.e. currently there is a missmatch between the xyz coordinates (fp) and the branchlens/pathlens (xp):

xyz1-----xyz2------xyz3-----------------xyz4--xyz5
loc1--------loc2--------loc3--------loc4--------loc5

rather than taking into account the correct pathlens

xyz1-----xyz2------xyz3-----------------xyz4--xyz5
loc1-----loc2------loc3-----------------loc4--loc5
