### PR TITLE
Add epsilon to branch_len

### DIFF
--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -296,7 +296,7 @@ def interpolate_xyz(loc: float, coords: np.ndarray):
     """
     dl = np.sqrt(np.sum(np.diff(coords[:, :3], axis=0) ** 2, axis=1))
     pathlens = np.insert(np.cumsum(dl), 0, 0)  # cummulative length of sections
-    norm_pathlens = pathlens / pathlens[-1]  # path lengths normalized to [0,1]
+    norm_pathlens = pathlens / np.maximum(1e-8, pathlens[-1])  # norm lengths to [0,1].
 
     return v_interp(loc, norm_pathlens, coords[:, :3])
 


### PR DESCRIPTION
This avoids issues with compartments (e.g. somas) that are traced with a single point.