### PR TITLE
Allow different nseg per branch and add `jax.sparse` solver

### DIFF
--- a/jaxley/build_branched_tridiag.py
+++ b/jaxley/build_branched_tridiag.py
@@ -54,10 +54,10 @@ def _define_tridiag_for_branch(
     """
 
     # Diagonal and solve.
-    a_v = 1.0 + dt * voltage_terms + dt * summed_coupling_conds
-    b_v = voltages + dt * i_ext
+    diags = 1.0 + dt * voltage_terms + dt * summed_coupling_conds
+    solves = voltages + dt * i_ext
 
     # Subdiagonals.
     upper = jnp.asarray(-dt * coupling_conds_upper)
     lower = jnp.asarray(-dt * coupling_conds_lower)
-    return lower, a_v, upper, b_v
+    return lower, diags, upper, solves

--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -120,7 +120,7 @@ def integrate(
     if param_state is not None:
         pstate += param_state
 
-    all_params = module.get_all_parameters(pstate)
+    all_params = module.get_all_parameters(pstate, voltage_solver=voltage_solver)
     all_states = (
         module.get_all_states(pstate, all_params, delta_t)
         if all_states is None

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -15,19 +15,24 @@ from jax.lax import ScatterDimensionNumbers, scatter_add
 from matplotlib.axes import Axes
 
 from jaxley.channels import Channel
-from jaxley.solver_voltage import step_voltage_explicit, step_voltage_implicit
+from jaxley.solver_voltage import (
+    step_voltage_explicit,
+    step_voltage_implicit_with_custom_spsolve,
+    step_voltage_implicit_with_jax_spsolve,
+)
 from jaxley.synapses import Synapse
 from jaxley.utils.cell_utils import (
     _compute_index_of_child,
     _compute_num_children,
     compute_levels,
     convert_point_process_to_distributed,
+    convert_to_csc,
     interpolate_xyz,
     loc_of_index,
     query_channel_states_and_params,
     v_interp,
 )
-from jaxley.utils.debug_solver import compute_morphology_indices, convert_to_csc
+from jaxley.utils.debug_solver import compute_morphology_indices
 from jaxley.utils.misc_utils import childview, concat_and_ignore_empty
 from jaxley.utils.plot_utils import plot_morph
 
@@ -252,7 +257,17 @@ class Module(ABC):
         return printable_nodes
 
     @abstractmethod
-    def init_conds(self, params: Dict):
+    def init_conds_jax_spsolve(self, params: Dict):
+        """Initialize coupling conductances.
+
+        Args:
+            params: Conductances and morphology parameters, not yet including
+                coupling conductances.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def init_conds_custom_spsolve(self, params: Dict):
         """Initialize coupling conductances.
 
         Args:
@@ -482,7 +497,9 @@ class Module(ABC):
         """
         return self.trainable_params
 
-    def get_all_parameters(self, pstate: List[Dict]) -> Dict[str, jnp.ndarray]:
+    def get_all_parameters(
+        self, pstate: List[Dict], voltage_solver: str
+    ) -> Dict[str, jnp.ndarray]:
         """Return all parameters (and coupling conductances) needed to simulate.
 
         Runs `init_conds()` and return every parameter that is needed to solve the ODE.
@@ -502,7 +519,13 @@ class Module(ABC):
 
         Args:
             pstate: The state of the trainable parameters. pstate takes the form
-                [{"key": "gNa", "indices": jnp.array([0, 1, 2]), "val": jnp.array([0.1, 0.2, 0.3])}, ...].
+                [{
+                    "key": "gNa", "indices": jnp.array([0, 1, 2]),
+                    "val": jnp.array([0.1, 0.2, 0.3])
+                }, ...].
+            voltage_solver: The voltage solver that is used. Since `jax.sparse` and
+                `jaxley.xyz` require different formats of the axial conductances, this
+                function will default to different building methods.
 
         Returns:
             A dictionary of all module parameters.
@@ -531,7 +554,10 @@ class Module(ABC):
                 params[key] = params[key].at[inds].set(set_param[:, None])
 
         # Compute conductance params and append them.
-        cond_params = self.init_conds(params)
+        if voltage_solver.startswith("jaxley"):
+            cond_params = self.init_conds_custom_spsolve(params)
+        else:
+            cond_params = self.init_conds_jax_spsolve(params)
         for key in cond_params:
             params[key] = cond_params[key]
 
@@ -594,7 +620,9 @@ class Module(ABC):
 
     def initialize(self):
         """Initialize the module."""
-        self.init_morph()
+        self.init_morph_custom_spsolve()
+        self.init_morph_jax_spsolve()
+        self.initialized_morph = True
         return self
 
     def init_states(self, delta_t: float = 0.025):
@@ -611,7 +639,9 @@ class Module(ABC):
 
         # We do not use any `pstate` for initializing. In principle, we could change
         # that by allowing an input `params` and `pstate` to this function.
-        params = self.get_all_parameters([])
+        # `voltage_solver` could also be `jax.sparse` here, because both of them
+        # build the channel parameters in the same way.
+        params = self.get_all_parameters([], voltage_solver="jaxley.thomas")
 
         for channel in self.channels:
             name = channel._name
@@ -918,43 +948,66 @@ class Module(ABC):
         # Voltage steps.
         cm = params["capacitance"]  # Abbreviation.
 
-        solver_kwargs = {
-            "voltages": voltages,
-            "voltage_terms": (v_terms + syn_v_terms) / cm,
-            "constant_terms": (const_terms + i_ext + syn_const_terms) / cm,
-            "coupling_conds_upper": params["branch_uppers"],
-            "coupling_conds_lower": params["branch_lowers"],
-            "summed_coupling_conds": params["branch_diags"],
-            "branchpoint_conds_children": params["branchpoint_conds_children"],
-            "branchpoint_conds_parents": params["branchpoint_conds_parents"],
-            "branchpoint_weights_children": params["branchpoint_weights_children"],
-            "branchpoint_weights_parents": params["branchpoint_weights_parents"],
-            "par_inds": self.par_inds,
-            "child_inds": self.child_inds,
-            "nbranches": self.total_nbranches,
-            "solver": voltage_solver,
-            "children_in_level": self.children_in_level,
-            "parents_in_level": self.parents_in_level,
-            "root_inds": self.root_inds,
-            "branchpoint_group_inds": self.branchpoint_group_inds,
-            "debug_states": self.debug_states,
-        }
+        if voltage_solver == "jax.sparse":
+            solver_kwargs = {
+                "voltages": voltages,
+                "voltage_terms": (v_terms + syn_v_terms) / cm,
+                "constant_terms": (const_terms + i_ext + syn_const_terms) / cm,
+                "axial_conductances": params["axial_conductances"],
+                "data_inds": self.data_inds,
+                "indices": self.indices,
+                "indptr": self.indptr,
+                "sinks": np.asarray(self.comp_edges["sink"].to_list()),
+                "n_nodes": self.n_nodes,
+                "internal_node_inds": self.internal_node_inds,
+            }
+            # Only for `bwd_euler` and `cranck-nicolson`.
+            step_voltage_implicit = step_voltage_implicit_with_jax_spsolve
+        else:
+            # Our custom sparse solver requires a different format of all conductance
+            # values to perform triangulation and backsubstution optimally.
+            #
+            # Currently, the forward Euler solver also uses this format. However,
+            # this is only for historical reasons and we are planning to change this in
+            # the future.
+            solver_kwargs = {
+                "voltages": voltages,
+                "voltage_terms": (v_terms + syn_v_terms) / cm,
+                "constant_terms": (const_terms + i_ext + syn_const_terms) / cm,
+                "coupling_conds_upper": params["branch_uppers"],
+                "coupling_conds_lower": params["branch_lowers"],
+                "summed_coupling_conds": params["branch_diags"],
+                "branchpoint_conds_children": params["branchpoint_conds_children"],
+                "branchpoint_conds_parents": params["branchpoint_conds_parents"],
+                "branchpoint_weights_children": params["branchpoint_weights_children"],
+                "branchpoint_weights_parents": params["branchpoint_weights_parents"],
+                "par_inds": self.par_inds,
+                "child_inds": self.child_inds,
+                "nbranches": self.total_nbranches,
+                "solver": voltage_solver,
+                "children_in_level": self.children_in_level,
+                "parents_in_level": self.parents_in_level,
+                "root_inds": self.root_inds,
+                "branchpoint_group_inds": self.branchpoint_group_inds,
+                "debug_states": self.debug_states,
+            }
+            # Only for `bwd_euler` and `cranck-nicolson`.
+            step_voltage_implicit = step_voltage_implicit_with_custom_spsolve
+
         if solver == "bwd_euler":
-            new_voltages = step_voltage_implicit(**solver_kwargs, delta_t=delta_t)
-            u["v"] = new_voltages.ravel(order="C")
-        elif solver == "fwd_euler":
-            new_voltages = step_voltage_explicit(**solver_kwargs, delta_t=delta_t)
-            u["v"] = new_voltages.ravel(order="C")
+            u["v"] = step_voltage_implicit(**solver_kwargs, delta_t=delta_t)
         elif solver == "crank_nicolson":
-            # Crank Nicolson advances by half a step of backward and half a step of
+            # Crank-Nicolson advances by half a step of backward and half a step of
             # forward Euler.
             half_step_delta_t = delta_t / 2
             half_step_voltages = step_voltage_implicit(
                 **solver_kwargs, delta_t=half_step_delta_t
             )
-            # The forward Euler step in Crank Nicolson can be performed easily as
+            # The forward Euler step in Crank-Nicolson can be performed easily as
             # `V_{n+1} = 2 * V_{n+1/2} - V_n`. See also NEURON book Chapter 4.
-            u["v"] = 2 * half_step_voltages.ravel(order="C") - voltages
+            u["v"] = 2 * half_step_voltages - voltages
+        elif solver == "fwd_euler":
+            u["v"] = step_voltage_explicit(**solver_kwargs, delta_t=delta_t)
         else:
             raise ValueError(
                 f"You specified `solver={solver}`. The only allowed solvers are "

--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -2,7 +2,7 @@
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 from math import pi
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import jax.numpy as jnp
 import numpy as np
@@ -339,12 +339,8 @@ def convert_point_process_to_distributed(
 
 
 def build_branchpoint_group_inds(
-    num_branchpoints,
-    child_belongs_to_branchpoint,
-    nseg,
-    nbranches,
+    num_branchpoints, child_belongs_to_branchpoint, start_ind_for_branchpoints
 ):
-    start_ind_for_branchpoints = nseg * nbranches
     branchpoint_inds_parents = start_ind_for_branchpoints + jnp.arange(num_branchpoints)
     branchpoint_inds_children = (
         start_ind_for_branchpoints + child_belongs_to_branchpoint
@@ -411,3 +407,124 @@ def query_channel_states_and_params(d, keys, idcs):
 
     Only loops over necessary keys, as opposed to looping over `d.items()`."""
     return dict(zip(keys, (v[idcs] for v in map(d.get, keys))))
+
+
+def convert_to_csc(
+    num_elements: int, row_ind: np.ndarray, col_ind: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Convert between two representations for sparse systems.
+
+    This is needed because `jax.scipy.linalg.spsolve` requires the `(ind, indptr)`
+    representation, but for `scipy` (and for intuition) we build the `(row, col)`
+    representation.
+
+    This function uses `np` instead of `jnp` because it only deals with indexing which
+    can be dealt with only based on the branch structure (i.e. independent of any
+    parameter values).
+
+    Written by ChatGPT.
+    """
+    data_inds = np.arange(num_elements)
+    # Step 1: Sort by (col_ind, row_ind)
+    sorted_indices = np.lexsort((row_ind, col_ind))
+    data_inds = data_inds[sorted_indices]
+    row_ind = row_ind[sorted_indices]
+    col_ind = col_ind[sorted_indices]
+
+    # Step 2: Create indptr array
+    n_cols = col_ind.max() + 1
+    indptr = np.zeros(n_cols + 1, dtype=int)
+    np.add.at(indptr, col_ind + 1, 1)
+    np.cumsum(indptr, out=indptr)
+
+    # Step 3: The row indices are already sorted
+    indices = row_ind
+
+    return data_inds, indices, indptr
+
+
+def comp_edges_to_indices(
+    comp_edges: pd.DataFrame,
+) -> Tuple[int, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Generates sparse matrix indices from the table of node edges.
+
+    This is only used for the `jax.sparse` voltage solver.
+
+    Args:
+        comp_edges: Dataframe with three columns (sink, source, type).
+
+    Returns:
+        n_nodes: The number of total nodes (including branchpoints).
+        data_inds: The indices to reorder the data.
+        indices and indptr: Indices passed to the sparse matrix solver.
+    """
+    # Build indices for diagonals.
+    sources = np.asarray(comp_edges["source"].to_list())
+    sinks = np.asarray(comp_edges["sink"].to_list())
+    n_nodes = np.max(sinks) + 1 if len(sinks) > 0 else 1
+    diagonal_inds = jnp.stack([jnp.arange(n_nodes), jnp.arange(n_nodes)])
+
+    # Build indices for off-diagonals.
+    off_diagonal_inds = jnp.stack([sources, sinks]).astype(int)
+
+    # Concatenate indices of diagonals and off-diagonals.
+    all_inds = jnp.concatenate([diagonal_inds, off_diagonal_inds], axis=1)
+
+    # Cast (row, col) indices to the format required for the `jax` sparse solver.
+    data_inds, indices, indptr = convert_to_csc(
+        num_elements=all_inds.shape[1],
+        row_ind=all_inds[0],
+        col_ind=all_inds[1],
+    )
+    return n_nodes, data_inds, indices, indptr
+
+
+def compute_axial_conductances(
+    comp_edges: pd.DataFrame, params: Dict[str, jnp.ndarray]
+) -> jnp.ndarray:
+    """Given `comp_edges`, radius, length, r_a, compute the axial conductances."""
+    # `Compartment-to-compartment` conductances.
+    condition = comp_edges["type"].to_numpy() == 0
+    source_comp_inds = np.asarray(comp_edges[condition]["source"].to_list())
+    sink_comp_inds = np.asarray(comp_edges[condition]["sink"].to_list())
+
+    conds0 = vmap(compute_coupling_cond, in_axes=(0, 0, 0, 0, 0, 0))(
+        params["radius"][sink_comp_inds],
+        params["radius"][source_comp_inds],
+        params["axial_resistivity"][sink_comp_inds],
+        params["axial_resistivity"][source_comp_inds],
+        params["length"][sink_comp_inds],
+        params["length"][source_comp_inds],
+    )
+
+    # `branchpoint-to-compartment` conductances.
+    condition = comp_edges["type"].to_numpy() == 1
+    sink_comp_inds = np.asarray(comp_edges[condition]["sink"].to_list())
+
+    if len(sink_comp_inds) > 0:
+        conds1 = vmap(compute_coupling_cond_branchpoint, in_axes=(0, 0, 0))(
+            params["radius"][sink_comp_inds],
+            params["axial_resistivity"][sink_comp_inds],
+            params["length"][sink_comp_inds],
+        )
+    else:
+        conds1 = jnp.asarray([])
+
+    # `compartment-to-branchpoint` conductances.
+    condition = comp_edges["type"].to_numpy() == 2
+    source_comp_inds = np.asarray(comp_edges[condition]["source"].to_list())
+
+    if len(source_comp_inds) > 0:
+        conds2 = vmap(compute_impact_on_node, in_axes=(0, 0, 0))(
+            params["radius"][source_comp_inds],
+            params["axial_resistivity"][source_comp_inds],
+            params["length"][source_comp_inds],
+        )
+        # For numerical stability. These values are very small, but their scale
+        # does not matter.
+        conds2 *= 1_000
+    else:
+        conds2 = jnp.asarray([])
+
+    # All conductances.
+    return jnp.concatenate([conds0, conds1, conds2])

--- a/jaxley/utils/debug_solver.py
+++ b/jaxley/utils/debug_solver.py
@@ -183,37 +183,3 @@ def drop_nseg_th_element(
     )
 
     return result
-
-
-def convert_to_csc(
-    num_elements: int, row_ind: np.ndarray, col_ind: np.ndarray
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Convert between two representations for sparse systems.
-
-    This is needed because `jax.scipy.linalg.spsolve` requires the `(ind, indptr)`
-    representation, but for `scipy` (and for intuition) we build the `(row, col)`
-    representation.
-
-    This function uses `np` instead of `jnp` because it only deals with indexing which
-    can be dealt with only based on the branch structure (i.e. independent of any
-    parameter values).
-
-    Written by ChatGPT.
-    """
-    data_inds = np.arange(num_elements)
-    # Step 1: Sort by (col_ind, row_ind)
-    sorted_indices = np.lexsort((row_ind, col_ind))
-    data_inds = data_inds[sorted_indices]
-    row_ind = row_ind[sorted_indices]
-    col_ind = col_ind[sorted_indices]
-
-    # Step 2: Create indptr array
-    n_cols = col_ind.max() + 1
-    indptr = np.zeros(n_cols + 1, dtype=int)
-    np.add.at(indptr, col_ind + 1, 1)
-    np.cumsum(indptr, out=indptr)
-
-    # Step 3: The row indices are already sorted
-    indices = row_ind
-
-    return data_inds, indices, indptr

--- a/tests/jaxley_identical/test_radius_and_length.py
+++ b/tests/jaxley_identical/test_radius_and_length.py
@@ -15,13 +15,15 @@ os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = ".8"
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import jaxley as jx
 from jaxley.channels import HH
 from jaxley.synapses import IonotropicSynapse
 
 
-def test_radius_and_length_compartment():
+@pytest.mark.parametrize("voltage_solver", ["jaxley.stone", "jax.sparse"])
+def test_radius_and_length_compartment(voltage_solver: str):
     dt = 0.025  # ms
     t_max = 5.0  # ms
     current = jx.step_current(0.5, 1.0, 0.02, dt, t_max)
@@ -36,7 +38,7 @@ def test_radius_and_length_compartment():
     comp.record()
     comp.stimulate(current)
 
-    voltages = jx.integrate(comp, delta_t=dt)
+    voltages = jx.integrate(comp, delta_t=dt, voltage_solver=voltage_solver)
 
     voltages_081123 = jnp.asarray(
         [
@@ -60,7 +62,8 @@ def test_radius_and_length_compartment():
     assert max_error <= tolerance, f"Error is {max_error} > {tolerance}"
 
 
-def test_radius_and_length_branch():
+@pytest.mark.parametrize("voltage_solver", ["jaxley.stone", "jax.sparse"])
+def test_radius_and_length_branch(voltage_solver: str):
     nseg_per_branch = 2
     dt = 0.025  # ms
     t_max = 5.0  # ms
@@ -77,7 +80,7 @@ def test_radius_and_length_branch():
     branch.loc(0.0).record()
     branch.loc(0.0).stimulate(current)
 
-    voltages = jx.integrate(branch, delta_t=dt)
+    voltages = jx.integrate(branch, delta_t=dt, voltage_solver=voltage_solver)
 
     voltages_300724 = jnp.asarray(
         [
@@ -101,7 +104,8 @@ def test_radius_and_length_branch():
     assert max_error <= tolerance, f"Error is {max_error} > {tolerance}"
 
 
-def test_radius_and_length_cell():
+@pytest.mark.parametrize("voltage_solver", ["jaxley.stone", "jax.sparse"])
+def test_radius_and_length_cell(voltage_solver: str):
     nseg_per_branch = 2
     dt = 0.025  # ms
     t_max = 5.0  # ms
@@ -126,7 +130,7 @@ def test_radius_and_length_cell():
     cell.branch(1).loc(0.0).record()
     cell.branch(1).loc(0.0).stimulate(current)
 
-    voltages = jx.integrate(cell, delta_t=dt)
+    voltages = jx.integrate(cell, delta_t=dt, voltage_solver=voltage_solver)
 
     voltages_300724 = jnp.asarray(
         [
@@ -150,7 +154,8 @@ def test_radius_and_length_cell():
     assert max_error <= tolerance, f"Error is {max_error} > {tolerance}"
 
 
-def test_radius_and_length_net():
+@pytest.mark.parametrize("voltage_solver", ["jaxley.stone", "jax.sparse"])
+def test_radius_and_length_net(voltage_solver: str):
     nseg_per_branch = 2
     dt = 0.025  # ms
     t_max = 5.0  # ms
@@ -200,7 +205,7 @@ def test_radius_and_length_net():
     for stim_ind in range(2):
         network.cell(stim_ind).branch(1).loc(0.0).stimulate(current)
 
-    voltages = jx.integrate(network, delta_t=dt)
+    voltages = jx.integrate(network, delta_t=dt, voltage_solver=voltage_solver)
 
     voltages_300724 = jnp.asarray(
         [

--- a/tests/jaxley_vs_neuron/test_cell.py
+++ b/tests/jaxley_vs_neuron/test_cell.py
@@ -130,3 +130,116 @@ def _run_neuron(i_delay, i_dur, i_amp, dt, t_max, solver):
 
     voltages = np.asarray([list(voltage1), list(voltage2), list(voltage3)])
     return voltages
+
+
+def test_similarity_unequal_number_of_compartments():
+    """Test similarity of jaxley vs neuron."""
+    i_delay = 3.0  # ms
+    i_dur = 2.0  # ms
+    i_amp = 1.0  # nA
+
+    dt = 0.025  # ms
+    t_max = 10.0  # ms
+
+    voltages_jaxley = _run_jaxley_unequal_ncomp(i_delay, i_dur, i_amp, dt, t_max)
+    voltages_neuron = _run_neuron_unequal_ncomp(i_delay, i_dur, i_amp, dt, t_max)
+
+    assert np.mean(np.abs(voltages_jaxley - voltages_neuron)) < 0.05
+
+
+def _run_jaxley_unequal_ncomp(i_delay, i_dur, i_amp, dt, t_max):
+    comp = jx.Compartment()
+    branch1 = jx.Branch(comp, nseg=1)
+    branch2 = jx.Branch(comp, nseg=2)
+    branch3 = jx.Branch(comp, nseg=3)
+    branch4 = jx.Branch(comp, nseg=4)
+    cell = jx.Cell([branch1, branch2, branch3, branch4], parents=[-1, 0, 0, 1])
+    cell.set("axial_resistivity", 10_000.0)
+    cell.insert(HH())
+
+    cell.set("radius", 5.0)
+    cell.set("length", 20.0)
+    cell.set("axial_resistivity", 1_000.0)
+
+    cell.set("HH_gNa", 0.120)
+    cell.set("HH_gK", 0.036)
+    cell.set("HH_gLeak", 0.0003)
+    cell.set("HH_m", 0.07490098835688629)
+    cell.set("HH_h", 0.488947681848153)
+    cell.set("HH_n", 0.3644787002343737)
+    cell.set("v", -62.0)
+
+    current = jx.step_current(i_delay, i_dur, i_amp, dt, t_max)
+    cell.branch(1).comp(1).stimulate(current)
+    cell.branch(0).comp(0).record()
+    cell.branch(2).comp(2).record()
+    cell.branch(3).comp(1).record()
+    cell.branch(3).comp(3).record()
+
+    voltages = jx.integrate(cell, delta_t=dt, voltage_solver="jax.sparse")
+    return voltages
+
+
+def _run_neuron_unequal_ncomp(i_delay, i_dur, i_amp, dt, t_max):
+    h.secondorder = 0
+    h.dt = dt
+
+    for sec in h.allsec():
+        h.delete_section(sec=sec)
+
+    branch1 = h.Section()
+    branch2 = h.Section()
+    branch3 = h.Section()
+    branch4 = h.Section()
+
+    branch2.connect(branch1, 1, 0)
+    branch3.connect(branch1, 1, 0)
+    branch4.connect(branch2, 1, 0)
+
+    nsegs = [1, 2, 3, 4]
+    for i, sec in enumerate(h.allsec()):
+        sec.nseg = nsegs[i]
+
+        sec.Ra = 1_000.0
+        sec.L = 20.0 * nsegs[i]
+        sec.diam = 2 * 5.0
+
+        sec.insert("hh")
+        sec.gnabar_hh = 0.120  # S/cm2
+        sec.gkbar_hh = 0.036  # S/cm2
+        sec.gl_hh = 0.0003  # S/cm2
+        sec.ena = 50  # mV
+        sec.ek = -77.0  # mV
+        sec.el_hh = -54.3  # mV
+
+    stim = h.IClamp(branch2(0.6))  # The second out of two.
+    stim.delay = i_delay
+    stim.dur = i_dur
+    stim.amp = i_amp
+
+    voltage1 = h.Vector()
+    voltage1.record(branch1(0.5)._ref_v)  # Only 1 compartment.
+    voltage2 = h.Vector()
+    voltage2.record(branch3(0.8)._ref_v)  # The third out of three compartments.
+    voltage3 = h.Vector()
+    voltage3.record(branch4(0.3)._ref_v)  # The second out of four comps.
+    voltage4 = h.Vector()
+    voltage4.record(branch4(0.9)._ref_v)  # The last out of four comps.
+
+    v_init = -62.0
+
+    def initialize():
+        h.finitialize(v_init)
+        h.fcurrent()
+
+    def integrate():
+        while h.t < t_max:
+            h.fadvance()
+
+    initialize()
+    integrate()
+
+    voltages = np.asarray(
+        [list(voltage1), list(voltage2), list(voltage3), list(voltage4)]
+    )
+    return voltages

--- a/tests/test_make_trainable.py
+++ b/tests/test_make_trainable.py
@@ -122,7 +122,7 @@ def test_diverse_synapse_types():
     params[1]["TestSynapse_gC"] = params[1]["TestSynapse_gC"].at[1].set(4.4)
     net.to_jax()
     pstate = params_to_pstate(params, net.indices_set_by_trainables)
-    all_parameters = net.get_all_parameters(pstate)
+    all_parameters = net.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
     assert np.all(all_parameters["radius"] == 1.0)
     assert np.all(all_parameters["length"] == 10.0)
@@ -142,7 +142,7 @@ def test_diverse_synapse_types():
     params[2]["IonotropicSynapse_gS"] = params[2]["IonotropicSynapse_gS"].at[:].set(5.5)
     net.to_jax()
     pstate = params_to_pstate(params, net.indices_set_by_trainables)
-    all_parameters = net.get_all_parameters(pstate)
+    all_parameters = net.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
     assert np.all(all_parameters["IonotropicSynapse_gS"][0] == 2.2)
     assert np.all(all_parameters["IonotropicSynapse_gS"][1] == 5.5)
 
@@ -230,7 +230,7 @@ def get_params_subset_trainable(net):
     params[0]["HH_gNa"] = params[0]["HH_gNa"].at[:].set(0.0)
     net.to_jax()
     pstate = params_to_pstate(params, net.indices_set_by_trainables)
-    return net.get_all_parameters(pstate)
+    return net.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
 
 def get_params_set_subset(net):
@@ -238,7 +238,7 @@ def get_params_set_subset(net):
     params = net.get_parameters()
     net.to_jax()
     pstate = params_to_pstate(params, net.indices_set_by_trainables)
-    return net.get_all_parameters(pstate)
+    return net.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
 
 def get_params_all_trainable(net):
@@ -247,7 +247,7 @@ def get_params_all_trainable(net):
     params[0]["HH_gNa"] = params[0]["HH_gNa"].at[:].set(0.0)
     net.to_jax()
     pstate = params_to_pstate(params, net.indices_set_by_trainables)
-    return net.get_all_parameters(pstate)
+    return net.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
 
 def get_params_set(net):
@@ -255,7 +255,7 @@ def get_params_set(net):
     params = net.get_parameters()
     net.to_jax()
     pstate = params_to_pstate(params, net.indices_set_by_trainables)
-    return net.get_all_parameters(pstate)
+    return net.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
 
 def test_make_trainable_corresponds_to_set_pospischil():
@@ -268,7 +268,7 @@ def test_make_trainable_corresponds_to_set_pospischil():
     params1[0]["vt"] = params1[0]["vt"].at[:].set(0.05)
     net1.to_jax()
     pstate1 = params_to_pstate(params1, net1.indices_set_by_trainables)
-    all_params1 = net1.get_all_parameters(pstate1)
+    all_params1 = net1.get_all_parameters(pstate1, voltage_solver="jaxley.thomas")
 
     net2.cell(0).insert(Na())
     net2.insert(K())
@@ -277,7 +277,7 @@ def test_make_trainable_corresponds_to_set_pospischil():
     params2[0]["vt"] = params2[0]["vt"].at[:].set(0.05)
     net2.to_jax()
     pstate2 = params_to_pstate(params2, net2.indices_set_by_trainables)
-    all_params2 = net2.get_all_parameters(pstate2)
+    all_params2 = net2.get_all_parameters(pstate2, voltage_solver="jaxley.thomas")
     assert np.array_equal(all_params1["vt"], all_params2["vt"], equal_nan=True)
     assert np.array_equal(all_params1["Na_gNa"], all_params2["Na_gNa"], equal_nan=True)
     assert np.array_equal(all_params1["K_gK"], all_params2["K_gK"], equal_nan=True)
@@ -313,14 +313,14 @@ def test_group_trainable_corresponds_to_set():
     params[0]["radius"] = params[0]["radius"].at[:].set(2.5)
     net1.to_jax()
     pstate = params_to_pstate(params, net1.indices_set_by_trainables)
-    all_parameters1 = net1.get_all_parameters(pstate)
+    all_parameters1 = net1.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
     net2 = build_net()
     net2.test.set("radius", 2.5)
     params = net2.get_parameters()
     net2.to_jax()
     pstate = params_to_pstate(params, net2.indices_set_by_trainables)
-    all_parameters2 = net2.get_all_parameters(pstate)
+    all_parameters2 = net2.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
     assert np.allclose(all_parameters1["radius"], all_parameters2["radius"])
 
@@ -334,14 +334,14 @@ def test_data_set_vs_make_trainable_pospischil():
     params1[0]["vt"] = params1[0]["vt"].at[:].set(0.05)
     net1.to_jax()
     pstate1 = params_to_pstate(params1, net1.indices_set_by_trainables)
-    all_params1 = net1.get_all_parameters(pstate1)
+    all_params1 = net1.get_all_parameters(pstate1, voltage_solver="jaxley.thomas")
 
     net2.cell(0).insert(Na())
     net2.insert(K())
     val = params1[0]["vt"]
     pstate = net2.cell("all").branch("all").loc("all").data_set("vt", val.item(), None)
     net2.to_jax()
-    all_params2 = net2.get_all_parameters(pstate)
+    all_params2 = net2.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
     assert np.array_equal(all_params1["vt"], all_params2["vt"], equal_nan=True)
     assert np.array_equal(all_params1["Na_gNa"], all_params2["Na_gNa"], equal_nan=True)
     assert np.array_equal(all_params1["K_gK"], all_params2["K_gK"], equal_nan=True)


### PR DESCRIPTION
# New features

### Different nseg for every branch

This PR enables that every branch can have a different number of compartments.
```python
comp = jx.Compartment()
branch1 = jx.Branch(comp, nseg=1)
branch2 = jx.Branch(comp, nseg=2)
branch3 = jx.Branch(comp, nseg=3)
cell = jx.Cell([branch1, branch2, branch3], parents=[-1, 0, 0])
cell.insert(HH())

cell.branch(1).comp(1).stimulate(jx.step_current(0.5, 1.0, 0.1, 0.025, 5.0))
cell.branch(0).comp(0).record()

voltages = jx.integrate(cell, delta_t=dt, voltage_solver="jax.sparse")
```

This is achieved by:
1) Building infrastructure to deal with a different number of compartments and
2) relying on `jax.experimental.sparse.spsolve` as a generic solver.


### Generic sparse voltage solver

With this PR, we are now supporting `jx.integrate(..., voltage_solver="jax.sparse")`. This uses the generic [sparse solver of JAX](https://jax.readthedocs.io/en/latest/_autosummary/jax.experimental.sparse.linalg.spsolve.html) for solving the voltage equations. It has the advantage that it has zero compile time and can more easily deal with different nseg, but the disadvantage that it does not support `vmap`. Unfortunately, the current voltage solvers (`jaxley.thomas` and `jaxley.stone`) need a different format for the sparse voltage solver than the `jax.sparse` solver. Therefore, we have to support both. This is achieved by:

1) Splitting `Module.init_morph()` into `Module._init_morph_jax_spsolve()` and `Module._init_morph_custom_spsolve()` (the latter is the one we already had).
2) Splitting `Module.init_conds()` into `Module._init_conds_jax_spsolve()` and `Module._init_conds_custom_spsolve()` (the latter is the one we already had).
3) Splitting `step_voltage_implicit()` (which lives in `jaxley.solver_voltage.py`) into `step_voltage_implicit_with_jax_spsolve()` and `step_voltage_implicit_with_custom_spsolve()`.


# Follow-up work

### Required future work before releasing
- Currently, `nseg` cannot be set after initialization. We should allow something like `cell.branch.set("nseg", 4)`.
- In a future PR, I will also allow using `jaxley.thomas` and `jaxley.stone` with different `nseg` per branch by masking out unused dimensions. This is done in #426 

### Optional follow-up work (probably after the next release)
- Raise an explicit error when `vmap` is used around the sparse jax solver.
- Consider making `jax.sparse` the default solver because of its low compile time.
- Benchmark the solvers and write a short tutorial about it.