### PR TITLE
Add /latest to all links in tutorials

### DIFF
--- a/tutorials/01_morph_neurons.ipynb
+++ b/tutorials/01_morph_neurons.ipynb
@@ -448,7 +448,7 @@
    "id": "eaa8df17-6f25-46a8-98d1-d28eb778780a",
    "metadata": {},
    "source": [
-    "Congrats! You have just run your first morphologically detailed neuron simulation in `Jaxley`. We suggest to continue by learning how to [build networks](https://jaxleyverse.github.io/jaxley/tutorial/02_small_network/). If you are only interested in single cell simulations, you can directly jump to learning how to [modify parameters of your simulation](https://jaxleyverse.github.io/jaxley/tutorial/03_setting_parameters/). If you want to simulate detailed morphologies from SWC files, checkout our tutorial on [working with detailed morphologies](https://jaxleyverse.github.io/jaxley/tutorial/08_importing_morphologies/)."
+    "Congrats! You have just run your first morphologically detailed neuron simulation in `Jaxley`. We suggest to continue by learning how to [build networks](https://jaxleyverse.github.io/jaxley/latest/tutorial/02_small_network/). If you are only interested in single cell simulations, you can directly jump to learning how to [modify parameters of your simulation](https://jaxleyverse.github.io/jaxley/latest/tutorial/03_setting_parameters/). If you want to simulate detailed morphologies from SWC files, checkout our tutorial on [working with detailed morphologies](https://jaxleyverse.github.io/jaxley/latest/tutorial/08_importing_morphologies/)."
    ]
   }
  ],
@@ -468,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/02_small_network.ipynb
+++ b/tutorials/02_small_network.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "### Define the network\n",
     "\n",
-    "First, we define a cell as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/tutorial/01_morph_neurons/)."
+    "First, we define a cell as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/latest/tutorial/01_morph_neurons/)."
    ]
   },
   {
@@ -406,7 +406,7 @@
    "id": "38e85474-520c-4b27-a14a-d67755540bb3",
    "metadata": {},
    "source": [
-    "That's it! You now know how to simulate networks of morphologically detailed neurons. Next, you should learn how to modify parameters of your simulation in [this tutorial](https://jaxleyverse.github.io/jaxley/tutorial/03_setting_parameters/)."
+    "That's it! You now know how to simulate networks of morphologically detailed neurons. Next, you should learn how to modify parameters of your simulation in [this tutorial](https://jaxleyverse.github.io/jaxley/latest/tutorial/03_setting_parameters/)."
    ]
   }
  ],
@@ -426,7 +426,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/03_setting_parameters.ipynb
+++ b/tutorials/03_setting_parameters.ipynb
@@ -883,7 +883,7 @@
    "id": "7bec5ecb-ba6a-49da-b75b-336821fd849b",
    "metadata": {},
    "source": [
-    "You can now modify parameters of your `Jaxley` simulation. In [the next tutorial](https://jaxleyverse.github.io/jaxley/tutorial/04_jit_and_vmap/), you will learn how to make parameter sweeps (or stimulus sweeps) fast with jit-compilation and GPU parallelization."
+    "You can now modify parameters of your `Jaxley` simulation. In [the next tutorial](https://jaxleyverse.github.io/jaxley/latest/tutorial/04_jit_and_vmap/), you will learn how to make parameter sweeps (or stimulus sweeps) fast with jit-compilation and GPU parallelization."
    ]
   }
  ],
@@ -903,7 +903,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/04_jit_and_vmap.ipynb
+++ b/tutorials/04_jit_and_vmap.ipynb
@@ -423,9 +423,9 @@
    "source": [
     "### Next steps\n",
     "\n",
-    "If you want to learn more, we recommend you to read the [tutorial on building channel and synapse models](https://jaxleyverse.github.io/jaxley/tutorial/05_channel_and_synapse_models/) or to read the [tutorial on groups](https://jaxleyverse.github.io/jaxley/tutorial/06_groups/), which allow to make your `Jaxley` simulations more elegant and convenient to interact with.\n",
+    "If you want to learn more, we recommend you to read the [tutorial on building channel and synapse models](https://jaxleyverse.github.io/jaxley/latest/tutorial/05_channel_and_synapse_models/) or to read the [tutorial on groups](https://jaxleyverse.github.io/jaxley/latest/tutorial/06_groups/), which allow to make your `Jaxley` simulations more elegant and convenient to interact with.\n",
     "\n",
-    "Alternatively, you can also directly jump ahead to the [tutorial on training biophysical networks](https://jaxleyverse.github.io/jaxley/tutorial/07_gradient_descent/) which will teach you how you can optimize parameters of biophysical models with gradient descent."
+    "Alternatively, you can also directly jump ahead to the [tutorial on training biophysical networks](https://jaxleyverse.github.io/jaxley/latest/tutorial/07_gradient_descent/) which will teach you how you can optimize parameters of biophysical models with gradient descent."
    ]
   }
  ],
@@ -445,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/05_channel_and_synapse_models.ipynb
+++ b/tutorials/05_channel_and_synapse_models.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "- define your own ion channel models beyond the preconfigured channels in `Jaxley`  \n",
     "\n",
-    "This tutorial assumes that you have already learned how to [build basic simulations](https://jaxleyverse.github.io/jaxley/tutorial/01_morph_neurons/)."
+    "This tutorial assumes that you have already learned how to [build basic simulations](https://jaxleyverse.github.io/jaxley/latest/tutorial/01_morph_neurons/)."
    ]
   },
   {
@@ -39,7 +39,7 @@
    "id": "e141cff7-ffc1-4e4a-bfe5-2b87792de748",
    "metadata": {},
    "source": [
-    "First, we define a cell as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/tutorial/01_morph_neurons/):"
+    "First, we define a cell as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/latest/tutorial/01_morph_neurons/):"
    ]
   },
   {
@@ -269,7 +269,7 @@
    "source": [
     "### Your own synapse\n",
     "\n",
-    "The parts below assume that you have already learned how to [build network simulations in `Jaxley`](https://jaxleyverse.github.io/jaxley/tutorial/02_small_network/).\n",
+    "The parts below assume that you have already learned how to [build network simulations in `Jaxley`](https://jaxleyverse.github.io/jaxley/latest/tutorial/02_small_network/).\n",
     "\n",
     "The below is an example of how to define your own synapse model in `Jaxley`:`"
    ]
@@ -403,9 +403,9 @@
    "source": [
     "That's it! You are now ready to build your own custom simulations and equip them with channel and synapse models!\n",
     "\n",
-    "This tutorial does not have an immediate follow-up tutorial. You could read the [tutorial on groups](https://jaxleyverse.github.io/jaxley/tutorial/06_groups/), which allow to make your `Jaxley` simulations more elegant and convenient to interact with.\n",
+    "This tutorial does not have an immediate follow-up tutorial. You could read the [tutorial on groups](https://jaxleyverse.github.io/jaxley/latest/tutorial/06_groups/), which allow to make your `Jaxley` simulations more elegant and convenient to interact with.\n",
     "\n",
-    "Alternatively, you can also directly jump ahead to the [tutorial on training biophysical networks](https://jaxleyverse.github.io/jaxley/tutorial/07_gradient_descent/) which will teach you how you can optimize parameters of biophysical models with gradient descent."
+    "Alternatively, you can also directly jump ahead to the [tutorial on training biophysical networks](https://jaxleyverse.github.io/jaxley/latest/tutorial/07_gradient_descent/) which will teach you how you can optimize parameters of biophysical models with gradient descent."
    ]
   }
  ],

--- a/tutorials/06_groups.ipynb
+++ b/tutorials/06_groups.ipynb
@@ -67,7 +67,7 @@
    "id": "5a0aa81f",
    "metadata": {},
    "source": [
-    "First, we define a network as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/tutorial/01_morph_neurons/):"
+    "First, we define a network as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/latest/tutorial/01_morph_neurons/):"
    ]
   },
   {
@@ -1250,6 +1250,14 @@
    "source": [
     "Groups allow you to organize your simulation in a more intuitive way, and they allow to perform parameter sharing with `make_trainable()`."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbb41e31-3f5d-4b47-9292-c5751c562eba",
+   "metadata": {},
+   "source": [
+    "If you have not done so already, we recommend you to check out the tutorial on [how to compute the gradient and train biophysical models](https://jaxleyverse.github.io/jaxley/latest/tutorial/07_gradient_descent/)."
+   ]
   }
  ],
  "metadata": {
@@ -1268,7 +1276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/07_gradient_descent.ipynb
+++ b/tutorials/07_gradient_descent.ipynb
@@ -101,7 +101,7 @@
    "id": "6a6a8517",
    "metadata": {},
    "source": [
-    "First, we define a network as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/tutorial/01_morph_neurons/):"
+    "First, we define a network as you saw in the [previous tutorial](https://jaxleyverse.github.io/jaxley/latest/tutorial/01_morph_neurons/):"
    ]
   },
   {
@@ -893,7 +893,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/08_importing_morphologies.ipynb
+++ b/tutorials/08_importing_morphologies.ipynb
@@ -642,7 +642,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Congrats! You have now learned how to vizualize and build networks out of very complex morphologies. To simulate this network, you can follow the steps in the tutroial on [how to build a network](https://jaxleyverse.github.io/jaxley/tutorial/02_small_network/)."
+    "Congrats! You have now learned how to vizualize and build networks out of very complex morphologies. To simulate this network, you can follow the steps in the tutroial on [how to build a network](https://jaxleyverse.github.io/jaxley/latest/tutorial/02_small_network/)."
    ]
   }
  ],
@@ -662,7 +662,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Without this, one gets lost in an old version of the docs if one follows the links in the tutorials (I don't exactly know why to be honest).