### PR TITLE
Plotting of comp morphology

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1712,6 +1712,8 @@ class View:
         Args:
             ax: An axis into which to plot.
             col: The color for all branches.
+            type: Whether to plot as points ("scatter"), a line ("line") or the
+                actual volume of the compartment("volume").
             dims: Which dimensions to plot. 1=x, 2=y, 3=z coordinate. Must be a tuple of
                 two of them.
             morph_plot_kwargs: Keyword arguments passed to the plotting function.

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -33,8 +33,8 @@ from jaxley.utils.cell_utils import (
 )
 from jaxley.utils.debug_solver import compute_morphology_indices
 from jaxley.utils.misc_utils import childview, concat_and_ignore_empty
-from jaxley.utils.solver_utils import convert_to_csc
 from jaxley.utils.plot_utils import plot_comps, plot_morph
+from jaxley.utils.solver_utils import convert_to_csc
 
 
 class Module(ABC):
@@ -115,23 +115,37 @@ class Module(ABC):
         self.debug_states = {}
 
     def _update_nodes_with_xyz(self):
-        """Add xyz coordinates to nodes."""
+        """Add xyz coordinates of compartment centers to nodes.
+
+        Note: For sake of performance, interpolation is not done for each branch,
+        but once along a concatenated (and padded) array of all branches.
+        """
         num_branches = len(self.xyzr)
-        x = np.linspace(
-            0.5 / self.nseg,
-            (num_branches * 1 - 0.5 / self.nseg),
-            num_branches * self.nseg,
+        comp_ends = (
+            np.linspace(0, 1, self.nseg + 1).reshape(1, -1).repeat(num_branches, 0)
         )
-        x += np.arange(num_branches).repeat(
-            self.nseg
-        )  # add offset to prevent branch loc overlap
-        xp = np.hstack(
-            [np.linspace(0, 1, x.shape[0]) + 2 * i for i, x in enumerate(self.xyzr)]
+        comp_ends = comp_ends + 2 * np.arange(num_branches).reshape(
+            -1, 1
+        )  # inter-branch padding
+        comp_ends = comp_ends.reshape(-1)
+        branch_lens = []
+        for i, xyzr in enumerate(self.xyzr):
+            branch_len = np.sqrt(
+                np.sum(np.diff(xyzr[:, :3], axis=0) ** 2, axis=1)
+            ).cumsum()
+            branch_len = np.hstack([np.array([0]), branch_len])
+            branch_len = branch_len / branch_len.max() + 2 * i  # add padding like above
+            branch_len[np.isnan(branch_len)] = 0
+            branch_lens.append(branch_len)
+        branch_lens = np.hstack(branch_lens)
+        xyz = np.vstack(self.xyzr)[:, :3]
+        xyz = v_interp(comp_ends, branch_lens, xyz).reshape(
+            3, num_branches, self.nseg + 1
         )
-        xyz = v_interp(x, xp, np.vstack(self.xyzr)[:, :3])
+        centers = ((xyz[:, :, 1:] + xyz[:, :, :-1]) / 2).reshape(3, -1).T
         idcs = self.nodes["comp_index"]
-        self.nodes.loc[idcs, ["x", "y", "z"]] = xyz.T
-        return xyz.T
+        self.nodes.loc[idcs, ["x", "y", "z"]] = centers
+        return centers, xyz
 
     def __repr__(self):
         return f"{type(self).__name__} with {len(self.channels)} different channels. Use `.show()` for details."
@@ -1226,10 +1240,10 @@ class Module(ABC):
         morph_plot_kwargs: Dict,
     ) -> Axes:
         branches_inds = view["branch_index"].to_numpy()
-        
+
         if type == "volume":
-            return plot_comps(self, dims, ax, **morph_plot_kwargs)
-        
+            return plot_comps(self[:], dims, ax, **morph_plot_kwargs)
+
         coords = []
         for branch_ind in branches_inds:
             assert not np.any(

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1242,7 +1242,9 @@ class Module(ABC):
         branches_inds = view["branch_index"].to_numpy()
 
         if type == "volume":
-            return plot_comps(self[:], dims, ax, **morph_plot_kwargs)
+            return plot_comps(
+                self, view, dims=dims, ax=ax, col=col, **morph_plot_kwargs
+            )
 
         coords = []
         for branch_ind in branches_inds:

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -33,8 +33,8 @@ from jaxley.utils.cell_utils import (
 )
 from jaxley.utils.debug_solver import compute_morphology_indices
 from jaxley.utils.misc_utils import childview, concat_and_ignore_empty
-from jaxley.utils.plot_utils import plot_morph
 from jaxley.utils.solver_utils import convert_to_csc
+from jaxley.utils.plot_utils import plot_comps, plot_morph
 
 
 class Module(ABC):
@@ -1226,6 +1226,10 @@ class Module(ABC):
         morph_plot_kwargs: Dict,
     ) -> Axes:
         branches_inds = view["branch_index"].to_numpy()
+        
+        if type == "volume":
+            return plot_comps(self, dims, ax, **morph_plot_kwargs)
+        
         coords = []
         for branch_ind in branches_inds:
             assert not np.any(

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -152,10 +152,31 @@ class CompartmentView(View):
         self,
         ax: Optional[Axes] = None,
         col: str = "k",
+        type: str = "scatter",
         dims: Tuple[int] = (0, 1),
         morph_plot_kwargs: Dict = {},
     ) -> Axes:
+        """Visualize the compartment.
+
+        Args:
+            ax: An axis into which to plot.
+            col: The color for all branches.
+            type: Wether to plot as point ("scatter") or the projected volume ("volume").
+            dims: Which dimensions to plot. 1=x, 2=y, 3=z coordinate. Must be a tuple of
+                two of them.
+            morph_plot_kwargs: Keyword arguments passed to the plotting function.
+        """
         nodes = self.set_global_index_and_index(self.view)
+        if type == "volume":
+            return self.pointer._vis(
+                ax=ax,
+                col=col,
+                dims=dims,
+                view=nodes,
+                type="volume",
+                morph_plot_kwargs=morph_plot_kwargs,
+            )
+
         return self.pointer._scatter(
             ax=ax,
             col=col,

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -161,7 +161,7 @@ class CompartmentView(View):
         Args:
             ax: An axis into which to plot.
             col: The color for all branches.
-            type: Wether to plot as point ("scatter") or the projected volume ("volume").
+            type: Whether to plot as point ("scatter") or the projected volume ("volume").
             dims: Which dimensions to plot. 1=x, 2=y, 3=z coordinate. Must be a tuple of
                 two of them.
             morph_plot_kwargs: Keyword arguments passed to the plotting function.

--- a/jaxley/utils/plot_utils.py
+++ b/jaxley/utils/plot_utils.py
@@ -204,6 +204,7 @@ def plot_comps(
     assert not np.any(np.isnan(module.xyzr[0][:, :3])), "missing xyz coordinates."
     if "x" not in module.nodes.columns:
         module._update_nodes_with_xyz()
+        view[["x", "y", "z"]] = module.nodes.loc[view.index, ["x", "y", "z"]]
 
     branches_inds = np.unique(view["branch_index"].to_numpy())
     for idx in branches_inds:

--- a/jaxley/utils/plot_utils.py
+++ b/jaxley/utils/plot_utils.py
@@ -4,7 +4,12 @@
 from typing import Dict, Optional, Tuple
 
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.axes import Axes
+from numpy import ndarray
+from scipy.spatial import ConvexHull
+
+from jaxley.utils.cell_utils import v_interp
 
 
 def plot_morph(
@@ -14,7 +19,7 @@ def plot_morph(
     ax: Optional[Axes] = None,
     type: str = "line",
     morph_plot_kwargs: Dict = {},
-):
+) -> Axes:
     """Plot morphology.
 
     Args:
@@ -37,4 +42,119 @@ def plot_morph(
         else:
             raise NotImplementedError
 
+    return ax
+
+
+def extract_outline(points: ndarray) -> ndarray:
+    hull = ConvexHull(points)
+    hull_points = points[hull.vertices]
+    return hull_points
+
+
+def compute_rotation_matrix(axis: ndarray, angle: float) -> ndarray:
+    """
+    Return the rotation matrix associated with counterclockwise rotation about
+    the given axis by the given angle.
+    """
+    axis = axis / np.sqrt(np.dot(axis, axis))
+    a = np.cos(angle / 2.0)
+    b, c, d = -axis * np.sin(angle / 2.0)
+    aa, bb, cc, dd = a * a, b * b, c * c, d * d
+    bc, ad, ac, ab, bd, cd = b * c, a * d, a * c, a * b, b * d, c * d
+    return np.array(
+        [
+            [aa + bb - cc - dd, 2 * (bc + ad), 2 * (bd - ac)],
+            [2 * (bc - ad), aa + cc - bb - dd, 2 * (cd + ab)],
+            [2 * (bd + ac), 2 * (cd - ab), aa + dd - bb - cc],
+        ]
+    )
+
+
+def plot_cylinder_projection(
+    orientation: ndarray,
+    length: float,
+    radius: float,
+    center: ndarray,
+    dims: Tuple[int],
+    ax: Axes = None,
+    **kwargs,
+) -> Axes:
+    if ax is None:
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+
+    # Normalize axis vector
+    orientation = np.array(orientation)
+    orientation = orientation / np.linalg.norm(orientation)
+
+    # Create a rotation matrix to align the cylinder with the given axis
+    z_axis = np.array([0, 0, 1])
+    rotation_axis = np.cross(z_axis, orientation)
+    rotation_angle = np.arccos(np.dot(z_axis, orientation))
+
+    if np.allclose(rotation_axis, 0):
+        rotation_matrix = np.eye(3)
+    else:
+        rotation_matrix = compute_rotation_matrix(rotation_axis, rotation_angle)
+
+    # Define cylinder
+    resolution = 100
+    t = np.linspace(0, 2 * np.pi, resolution)
+    z = np.linspace(-length / 2, length / 2, resolution)
+    T, Z = np.meshgrid(t, z)
+
+    X = radius * np.cos(T)
+    Y = radius * np.sin(T)
+
+    # Rotate cylinder
+    points = np.dot(rotation_matrix, np.array([X.flatten(), Y.flatten(), Z.flatten()]))
+    X = points.reshape(3, -1)
+
+    # project onto plane and move
+    X = X[dims]
+    X += np.array(center)[dims, np.newaxis]
+
+    # get outline of cylinder mesh
+    X = extract_outline(X.T).T
+
+    ax.fill(X[0].flatten(), X[1].flatten(), **kwargs)
+    return ax
+
+
+# new vis function
+def plot_comps(
+    view,
+    dims: Tuple[int] = (0, 1),
+    ax: Optional[Axes] = None,
+    comp_plot_kwargs: Dict = {},
+):
+    if ax is None:
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+
+    branches_inds = np.unique(view.view["branch_index"].to_numpy())
+    for idx in branches_inds:
+        locs = view.pointer.xyzr[idx][:, :3]
+        if locs.shape[0] > 1:  # ignore single point branches for now
+            locs[np.isnan(locs)] = 0
+            lens = np.sqrt(np.nansum(np.diff(locs, axis=0) ** 2, axis=1))
+            lens = np.cumsum([0] + lens.tolist())
+            comp_ends = v_interp(
+                np.linspace(0, lens[-1], view.pointer.nseg + 1), lens, locs
+            ).T
+            comp_centers = np.array((comp_ends[1:] + comp_ends[:-1]) / 2)
+            axes = np.diff(comp_ends, axis=0)
+            cylinder_lens = np.sqrt(np.sum(axes**2, axis=1))
+
+        for l, center, (i, comp), axis in zip(
+            cylinder_lens, comp_centers, view.pointer.branch(idx).view.iterrows(), axes
+        ):
+            # center = comp[["x", "y", "z"]]
+            center[np.isnan(center)] = 0
+            radius = comp["radius"]
+            # length = l
+            length = comp["length"]
+            ax = plot_cylinder_projection(
+                axis, length, radius, center, dims, ax, **comp_plot_kwargs
+            )
     return ax

--- a/tests/test_plotting_api.py
+++ b/tests/test_plotting_api.py
@@ -153,3 +153,21 @@ def test_mixed_network():
         assert np.allclose(b[:, 1], a[:, 0], atol=1e-6)
 
     _ = net.vis(detail="full")
+
+
+def test_volume_plotting():
+    comp = jx.Compartment()
+    comp.compute_xyz()
+    branch = jx.Branch(comp, 4)
+    branch.compute_xyz()
+    cell = jx.Cell([branch] * 3, [-1, 0, 0])
+    cell.compute_xyz()
+    net = jx.Network([cell] * 4)
+    net.compute_xyz()
+
+    fig, ax = plt.subplots()
+    for module in [comp, branch, cell, net]:
+        module.vis(type="volume", ax=ax)
+        if not isinstance(module, jx.Compartment):
+            module[0].vis(type="volume", ax=ax)
+    plt.close(fig)


### PR DESCRIPTION
I got side-tracked while working on a different PR and implemented plotting of the actual compartment structure:

The compartments are rendered in 3D and then the correct projection of the 3d mesh is plotted on whatever plane. 
```
fig, ax = plt.subplots(2, 3, figsize=(10, 5))

for i, orientation in enumerate([np.array([1,1,2]), np.array([0,1,0.1]), np.array([0,0.1,1])]):
    plot_cylinder_projection(orientation, length=5, radius=1, center=np.array([0,0,0]), dims=[0,1], ax=ax[0,i])
    plot_cylinder_projection(orientation, length=5, radius=1, center=np.array([0,0,0]), dims=[1,2], ax=ax[1,i])
    ax[0,i].set_title(f"Orientation: {orientation}")
plt.show()
```
![image](https://github.com/user-attachments/assets/2581b65b-0442-4131-bc92-e366f49197c8)


Hence the compartment radii and lengths are correctly reflected in the plot.
![image](https://github.com/user-attachments/assets/47ad6a53-0fe9-469d-8e29-fb4335eadaf1)

However, plotting an imported morphology looked weird for some reason.
![image](https://github.com/user-attachments/assets/3de51f5c-0dfc-451a-b54e-3adc1492c7aa)

While looking into this, I noticed two things:
Since the cylindrical compartments are straight, they run from one compartment edge to the other on a straight line. However, they model a potentially very zigzaggy branch/path structure. This means:
a) Assuming the comp center is at loc=0.5 along the path (currently how we do it), can put the comp center off axis. 
b) Setting the comp length to the path length can result in comps which appear longer than the distance between their two endpoints.

This can be illustrated by adding a bit of noisy to the xyz coordinates of the example above.
![image](https://github.com/user-attachments/assets/2b30b465-dce3-4d3f-8984-c097ed02b077)

Changing the compartment centers to be the center of the cylinder, already produces much better looking plots.
![image](https://github.com/user-attachments/assets/4dde388f-80fa-464f-af0c-f06e2862b0f5)

While I dont think changing b) makes sense (apart from for visualization maybe) I think changing a) might be a good idea.

Lemme know your thoughts.

_PR is missing documentation, some cleanup and handling of single point cases._