### PR TITLE
Allow changing nseg after initialization

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -5,6 +5,7 @@ import inspect
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Callable, Dict, List, Optional, Tuple, Union
+from warnings import warn
 
 import jax.numpy as jnp
 import numpy as np
@@ -32,9 +33,14 @@ from jaxley.utils.cell_utils import (
     v_interp,
 )
 from jaxley.utils.debug_solver import compute_morphology_indices
-from jaxley.utils.misc_utils import childview, concat_and_ignore_empty
+from jaxley.utils.misc_utils import (
+    childview,
+    concat_and_ignore_empty,
+    cumsum_leading_zero,
+)
 from jaxley.utils.plot_utils import plot_comps, plot_morph
 from jaxley.utils.solver_utils import convert_to_csc
+from jaxley.utils.swc import build_radiuses_from_xyzr
 
 
 class Module(ABC):
@@ -109,6 +115,7 @@ class Module(ABC):
 
         # x, y, z coordinates and radius.
         self.xyzr: List[np.ndarray] = []
+        self._radius_generating_fns = None  # Defined by `.read_swc()`.
 
         # For debugging the solver. Will be empty by default and only filled if
         # `self._init_morph_for_debugging` is run.
@@ -156,6 +163,14 @@ class Module(ABC):
     def __dir__(self):
         base_dir = object.__dir__(self)
         return sorted(base_dir + self.synapse_names + list(self.group_nodes.keys()))
+
+    @property
+    def _module_type(self):
+        """Return type of the module (compartment, branch, cell, network) as string.
+
+        This is used to perform asserts for some modules (e.g. network cannot use
+        `set_ncomp`) without having to import the module in `base.py`."""
+        return self.__class__.__name__.lower()
 
     def _append_params_and_states(self, param_dict: Dict, state_dict: Dict):
         """Insert the default params of the module (e.g. radius, length).
@@ -394,6 +409,134 @@ class Module(ABC):
         else:
             raise KeyError("Key not recognized.")
         return param_state
+
+    def _set_ncomp(
+        self,
+        ncomp: int,
+        view: pd.DataFrame,
+        all_nodes: pd.DataFrame,
+        start_idx: int,
+        nseg_per_branch: jnp.asarray,
+        channel_names: List[str],
+        channel_param_names: List[str],
+        channel_state_names: List[str],
+        radius_generating_fns: List[Callable],
+        min_radius: Optional[float],
+    ):
+        """Set the number of compartments with which the branch is discretized."""
+        within_branch_radiuses = view["radius"].to_numpy()
+        compartment_lengths = view["length"].to_numpy()
+        num_previous_ncomp = len(within_branch_radiuses)
+        branch_indices = pd.unique(view["branch_index"])
+
+        error_msg = lambda name: (
+            f"You previously modified the {name} of individual compartments, but "
+            f"now you are modifying the number of compartments in this branch. "
+            f"This is not allowed. First build the morphology with `set_ncomp()` and "
+            f"then modify the radiuses and lengths of compartments."
+        )
+
+        if (
+            ~np.all(within_branch_radiuses == within_branch_radiuses[0])
+            and radius_generating_fns is None
+        ):
+            raise ValueError(error_msg("radius"))
+
+        for property_name in ["length", "capacitance", "axial_resistivity"]:
+            compartment_properties = view[property_name].to_numpy()
+            if ~np.all(compartment_properties == compartment_properties[0]):
+                raise ValueError(error_msg(property_name))
+
+        if not (view[channel_names].var() == 0.0).all():
+            raise ValueError(
+                "Some channel exists only in some compartments of the branch which you"
+                "are trying to modify. This is not allowed. First specify the number"
+                "of compartments with `.set_ncomp()` and then insert the channels"
+                "accordingly."
+            )
+
+        if not (view[channel_param_names + channel_state_names].var() == 0.0).all():
+            raise ValueError(
+                "Some channel has different parameters or states between the "
+                "different compartments of the branch which you are trying to modify. "
+                "This is not allowed. First specify the number of compartments with "
+                "`.set_ncomp()` and then insert the channels accordingly."
+            )
+
+        # Add new rows as the average of all rows. Special case for the length is below.
+        average_row = view.mean(skipna=False)
+        average_row = average_row.to_frame().T
+        view = pd.concat([*[average_row] * ncomp], axis="rows")
+
+        # If the `view` is not the entire `Module`, but a `View` (i.e. if one changes
+        # the number of comps within a branch of a cell), then the `self.pointer.view`
+        # will contain the additional `global_xyz_index` columns. However, the
+        # `self.nodes` will not have these columns.
+        #
+        # Note that we assert that there are no trainables, so `controlled_by_params`
+        # of the `self.nodes` has to be empty.
+        if "global_comp_index" in view.columns:
+            view = view.drop(
+                columns=[
+                    "global_comp_index",
+                    "global_branch_index",
+                    "global_cell_index",
+                    "controlled_by_param",
+                ]
+            )
+
+        # Set the correct datatype after having performed an average which cast
+        # everything to float.
+        integer_cols = ["comp_index", "branch_index", "cell_index"]
+        view[integer_cols] = view[integer_cols].astype(int)
+
+        # Whether or not a channel exists in a compartment is a boolean.
+        boolean_cols = channel_names
+        view[boolean_cols] = view[boolean_cols].astype(bool)
+
+        # Special treatment for the lengths and radiuses. These are not being set as
+        # the average because we:
+        # 1) Want to maintain the total length of a branch.
+        # 2) Want to use the SWC inferred radius.
+        #
+        # Compute new compartment lengths.
+        comp_lengths = np.sum(compartment_lengths) / ncomp
+        view["length"] = comp_lengths
+
+        # Compute new compartment radiuses.
+        if radius_generating_fns is not None:
+            view["radius"] = build_radiuses_from_xyzr(
+                radius_fns=radius_generating_fns,
+                branch_indices=branch_indices,
+                min_radius=min_radius,
+                nseg=ncomp,
+            )
+        else:
+            view["radius"] = within_branch_radiuses[0] * np.ones(ncomp)
+
+        # Update `.nodes`.
+        #
+        # 1) Delete N rows starting from start_idx
+        number_deleted = num_previous_ncomp
+        all_nodes = all_nodes.drop(index=range(start_idx, start_idx + number_deleted))
+
+        # 2) Insert M new rows at the same location
+        df1 = all_nodes.iloc[:start_idx]  # Rows before the insertion point
+        df2 = all_nodes.iloc[start_idx:]  # Rows after the insertion point
+
+        # 3) Combine the parts: before, new rows, and after
+        all_nodes = pd.concat([df1, view, df2]).reset_index(drop=True)
+
+        # Override `comp_index` to just be a consecutive list.
+        all_nodes["comp_index"] = np.arange(len(all_nodes))
+
+        # Update compartment structure arguments.
+        nseg_per_branch = nseg_per_branch.at[branch_indices].set(ncomp)
+        nseg = int(jnp.max(nseg_per_branch))
+        cumsum_nseg = cumsum_leading_zero(nseg_per_branch)
+        internal_node_inds = np.arange(cumsum_nseg[-1])
+
+        return all_nodes, nseg_per_branch, nseg, cumsum_nseg, internal_node_inds
 
     def make_trainable(
         self,

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -37,7 +37,7 @@ class Compartment(Module):
         super().__init__()
 
         self.nseg = 1
-        self.nseg_per_branch = [1]
+        self.nseg_per_branch = jnp.asarray([1])
         self.total_nbranches = 1
         self.nbranches_per_cell = [1]
         self.cumsum_nbranches = jnp.asarray([0, 1])

--- a/jaxley/utils/misc_utils.py
+++ b/jaxley/utils/misc_utils.py
@@ -3,6 +3,7 @@
 
 from typing import List, Optional, Union
 
+import jax.numpy as jnp
 import numpy as np
 import pandas as pd
 
@@ -33,3 +34,10 @@ def childview(
     if child_name != "/":
         return module.__getattr__(child_name)(index)
     raise AttributeError("Compartment does not support indexing")
+
+
+def cumsum_leading_zero(array: Union[jnp.ndarray, List]) -> jnp.ndarray:
+    """Return the `cumsum` of a jax array and pad with a leading zero."""
+    return jnp.concatenate([jnp.asarray([0]), jnp.cumsum(jnp.asarray(array))]).astype(
+        int
+    )

--- a/tests/test_set_ncomp.py
+++ b/tests/test_set_ncomp.py
@@ -1,0 +1,194 @@
+# This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
+# licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+
+import os
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_platform_name", "cpu")
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import jaxley as jx
+from jaxley.channels import HH
+
+
+@pytest.mark.parametrize(
+    "property", ["radius", "capacitance", "length", "axial_resistivity"]
+)
+def test_raise_for_heterogenous_modules(property):
+    comp = jx.Compartment()
+    branch0 = jx.Branch(comp, nseg=4)
+    branch1 = jx.Branch(comp, nseg=4)
+    branch1.comp(1).set(property, 1.5)
+    cell = jx.Cell([branch0, branch1], parents=[-1, 0])
+    with pytest.raises(ValueError):
+        cell.branch(1).set_ncomp(2)
+
+
+def test_raise_for_heterogenous_channel_existance():
+    comp = jx.Compartment()
+    branch0 = jx.Branch(comp, nseg=4)
+    branch1 = jx.Branch(comp, nseg=4)
+    branch1.comp(2).insert(HH())
+    cell = jx.Cell([branch0, branch1], parents=[-1, 0])
+    with pytest.raises(ValueError):
+        cell.branch(1).set_ncomp(2)
+
+
+def test_raise_for_heterogenous_channel_properties():
+    comp = jx.Compartment()
+    branch0 = jx.Branch(comp, nseg=4)
+    branch1 = jx.Branch(comp, nseg=4)
+    branch1.insert(HH())
+    branch1.comp(3).set("HH_gNa", 0.5)
+    cell = jx.Cell([branch0, branch1], parents=[-1, 0])
+    with pytest.raises(ValueError):
+        cell.branch(1).set_ncomp(2)
+
+
+def test_raise_for_entire_cells():
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, nseg=4)
+    cell = jx.Cell(branch, parents=[-1, 0, 0])
+    with pytest.raises(NotImplementedError):
+        cell.set_ncomp(2)
+
+
+def test_raise_for_networks():
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, nseg=4)
+    cell1 = jx.Cell(branch, parents=[-1, 0, 0])
+    cell2 = jx.Cell(branch, parents=[-1, 0, 0])
+    net = jx.Network([cell1, cell2])
+    with pytest.raises(NotImplementedError):
+        net.cell(0).branch(1).set_ncomp(2)
+
+
+def test_raise_for_recording():
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, nseg=4)
+    cell = jx.Cell(branch, parents=[-1, 0])
+    cell.branch(0).comp(0).record()
+    with pytest.raises(AssertionError):
+        cell.branch(1).set_ncomp(2)
+
+
+def test_raise_for_stimulus():
+    comp = jx.Compartment()
+    branch = jx.Branch(comp, nseg=4)
+    cell = jx.Cell(branch, parents=[-1, 0])
+    cell.branch(0).comp(0).stimulate(0.4 * jnp.ones(100))
+    with pytest.raises(AssertionError):
+        cell.branch(1).set_ncomp(2)
+
+
+@pytest.mark.parametrize("new_ncomp", [1, 2, 4, 5, 8])
+def test_simulation_accuracy_api_equivalence_init_vs_setncomp_branch(new_ncomp):
+    """Test whether a module built from scratch matches module built with `set_ncomp()`.
+
+    This makes one branch, whose `ncomp` is not modified, heterogenous.
+    """
+    comp = jx.Compartment()
+    branch1 = jx.Branch(comp, nseg=new_ncomp)
+
+    # The second branch is originally instantiated to have 4 ncomp, but is later
+    # modified to have `new_ncomp` compartments.
+    branch2 = jx.Branch(comp, nseg=4)
+    branch2.comp("all").set("length", 10.0)
+    total_branch_len = 4 * 10.0
+
+    # Make the total branch length 40 um.
+    branch1.comp("all").set("length", total_branch_len / new_ncomp)
+
+    # Adapt ncomp.
+    branch2.set_ncomp(new_ncomp)
+
+    for branch in [branch1, branch2]:
+        branch.comp(0).stimulate(0.4 * jnp.ones(100))
+        branch.comp(new_ncomp - 1).record()
+
+    v1 = jx.integrate(branch1)
+    v2 = jx.integrate(branch2)
+    max_error = np.max(np.abs(v1 - v2))
+    assert max_error < 1e-8, f"Too large voltage deviation, {max_error} > 1e-8"
+
+
+@pytest.mark.parametrize("new_ncomp", [1, 2, 4, 5, 8])
+def test_simulation_accuracy_api_equivalence_init_vs_setncomp_cell(new_ncomp):
+    """Test whether a module built from scratch matches module built with `set_ncomp()`."""
+    comp = jx.Compartment()
+    branch1 = jx.Branch(comp, nseg=new_ncomp)
+
+    # The second branch is originally instantiated to have 4 ncomp, but is later
+    # modified to have `new_ncomp` compartments.
+    branch2 = jx.Branch(comp, nseg=4)
+    branch2.comp("all").set("length", 10.0)
+    total_branch_len = 4 * 10.0
+
+    # Make the total branch length 20 um.
+    branch1.comp("all").set("length", total_branch_len / new_ncomp)
+    cell1 = jx.Cell(branch1, parents=[-1, 0])
+    cell2 = jx.Cell(branch2, parents=[-1, 0])
+
+    # Adapt ncomp.
+    for b in range(2):
+        cell2.branch(b).set_ncomp(new_ncomp)
+
+    for cell in [cell1, cell2]:
+        cell.branch(0).comp(0).stimulate(0.4 * jnp.ones(100))
+        cell.branch(1).comp(new_ncomp - 1).record()
+
+    v1 = jx.integrate(cell1)
+    v2 = jx.integrate(cell2)
+    max_error = np.max(np.abs(v1 - v2))
+    assert max_error < 1e-8, f"Too large voltage deviation, {max_error} > 1e-8"
+
+
+@pytest.mark.parametrize("new_ncomp", [1, 2, 4, 5, 8])
+@pytest.mark.parametrize("file", ["morph_250.swc"])
+def test_api_equivalence_swc_lengths_and_radiuses(new_ncomp, file):
+    """Test if the radiuses and lenghts of an SWC morph are reconstructed correctly."""
+    dirname = os.path.dirname(__file__)
+    fname = os.path.join(dirname, "swc_files", file)
+
+    cell1 = jx.read_swc(fname, nseg=new_ncomp, max_branch_len=2000.0)
+    cell2 = jx.read_swc(fname, nseg=4, max_branch_len=2000.0)
+
+    for b in range(cell2.total_nbranches):
+        cell2.branch(b).set_ncomp(new_ncomp)
+
+    for property_name in ["radius", "length"]:
+        cell1_vals = cell1.nodes[property_name].to_numpy()
+        cell2_vals = cell2.nodes[property_name].to_numpy()
+        assert np.allclose(
+            cell1_vals, cell2_vals
+        ), f"Too large difference in {property_name}"
+
+
+@pytest.mark.parametrize("new_ncomp", [1, 2, 4, 5, 8])
+@pytest.mark.parametrize("file", ["morph_250.swc"])
+def test_simulation_accuracy_swc_init_vs_set_ncomp(new_ncomp, file):
+    """Test whether an SWC initially built with 4 ncomp works after `set_ncomp()`."""
+    dirname = os.path.dirname(__file__)
+    fname = os.path.join(dirname, "swc_files", file)
+
+    cell1 = jx.read_swc(fname, nseg=new_ncomp, max_branch_len=2000.0)
+    cell2 = jx.read_swc(fname, nseg=4, max_branch_len=2000.0)
+
+    for b in range(cell2.total_nbranches):
+        cell2.branch(b).set_ncomp(new_ncomp)
+
+    for cell in [cell1, cell2]:
+        cell.branch(0).comp(0).stimulate(0.4 * jnp.ones(100))
+        cell.branch(0).comp(new_ncomp - 1).record()
+        cell.branch(3).comp(0).record()
+        cell.branch(5).comp(new_ncomp - 1).record()
+
+    v1 = jx.integrate(cell1, voltage_solver="jax.sparse")
+    v2 = jx.integrate(cell2, voltage_solver="jax.sparse")
+    max_error = np.max(np.abs(v1 - v2))
+    assert max_error < 1e-8, f"Too large voltage deviation, {max_error} > 1e-8"


### PR DESCRIPTION
This PR is a follow-up to #418 and #426. It allows to set `nseg` **after** initialization of the module. This is achieved with a new `set_ncomp` method. This PR is the final requirement for a new release with these features.

### API

Works for branches:
```python
comp = jx.Compartment()
branch = jx.Branch(comp, nseg=2)
branch.set_ncomp(4)
```

...for branches within a cell:
```python
comp = jx.Compartment()
branch = jx.Branch(comp, nseg=2)
cell = jx.Cell(branch, parents=[-1, 0, 0])
cell.branch(1).set_ncomp(4)
```

...and for branches read from SWC files, in which case it reuses the xyzr to compute optional radiuses:
```python
cell = jx.read_swc(fname, nseg=2)
cell.branch(1).set_ncomp(4)
```

### Assumption and `Raises`
The `set_ncomp` function will raise an error if:  
- There are stimuli in **any** compartment in the module  
- There are recordings in **any** compartment in the module  
- The channels of the compartments are not the same within the branch that is modified  
- The lengths of the compartments are not the same within the branch that is modified 

In addition, unlike the data was read from an SWC file, `.set_ncomp()` raises an error if:  
- The radiuses of the compartments are not the same within the branch that is modified  

Finally, we currently raise `NotImplementedError` if the `Module` is a `Network`, e.g. for
```python
net.cell(0).branch(1).set_ncomp(4)
```
This is because I do not want to deal with synapse indexing for now.

We also raise a `NotImplementedError` if the `Module` is an entire `Cell`, e.g. for
```python
cell.set_ncomp(4)
```