### PR TITLE
Fixups for having heterogenous numbers of compartments in each branch

### DIFF
--- a/jaxley/connect.py
+++ b/jaxley/connect.py
@@ -139,6 +139,9 @@ def sparse_connect(
     global_pre_indices = pre_cell_view.pointer._cumsum_nseg_per_cell[pre_cell_inds]
     pre_rows = pre_cell_view.view.loc[global_pre_indices]
 
+    print("pre_rows", len(pre_rows))
+    print("post_rows", len(post_rows))
+
     pre_cell_view._append_multiple_synapses(pre_rows, post_rows, synapse_type)
 
 

--- a/jaxley/connect.py
+++ b/jaxley/connect.py
@@ -136,9 +136,7 @@ def sparse_connect(
     post_rows = post_cell_view.view.loc[global_post_indices]
 
     # Pre-synapse is at the zero-eth branch and zero-eth compartment.
-    idcs_to_zero = np.zeros_like(num_pre)
-    get_global_idx = pre_cell_view.pointer._local_inds_to_global
-    global_pre_indices = get_global_idx(pre_syn_neurons, idcs_to_zero, idcs_to_zero)
+    global_pre_indices = pre_cell_view.pointer._cumsum_nseg_per_cell[pre_cell_inds]
     pre_rows = pre_cell_view.view.loc[global_pre_indices]
 
     pre_cell_view._append_multiple_synapses(pre_rows, post_rows, synapse_type)
@@ -182,9 +180,8 @@ def connectivity_matrix_connect(
     ]
     post_rows = post_cell_view.view.loc[global_post_indices]
 
-    idcs_to_zero = np.zeros_like(from_idx)
-    get_global_idx = post_cell_view.pointer._local_inds_to_global
-    global_pre_indices = get_global_idx(pre_cell_inds, idcs_to_zero, idcs_to_zero)
+    # Pre-synapse is at the zero-eth branch and zero-eth compartment.
+    global_pre_indices = pre_cell_view.pointer._cumsum_nseg_per_cell[pre_cell_inds]
     pre_rows = pre_cell_view.view.loc[global_pre_indices]
 
     pre_cell_view._append_multiple_synapses(pre_rows, post_rows, synapse_type)

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -2019,9 +2019,6 @@ class View:
             self.pointer.nseg_per_branch[pre_rows["global_branch_index"].to_numpy()],
         )
 
-        print("post_rows", len(post_rows))
-        print("pre_rows", len(pre_rows))
-
         # Define new synapses. Each row is one synapse.
         new_rows = dict(
             pre_locs=pre_loc,

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1416,7 +1416,9 @@ class Module(ABC):
             np.isnan(self.xyzr[branch_ind][:, dims])
         ), "No coordinates available. Use `vis(detail='point')` or run `.compute_xyz()` before running `.vis()`."
 
-        comp_fraction = loc_of_index(comp_ind, self.nseg)
+        comp_fraction = loc_of_index(
+            comp_ind, branch_ind, self.cumsum_nseg, self.nseg_per_branch
+        )
         coords = self.xyzr[branch_ind]
         interpolated_xyz = interpolate_xyz(comp_fraction, coords)
 
@@ -1677,15 +1679,6 @@ class Module(ABC):
     def __iter__(self):
         for i in range(self.shape[0]):
             yield self[i]
-
-    def _local_inds_to_global(
-        self, cell_inds: np.ndarray, branch_inds: np.ndarray, comp_inds: np.ndarray
-    ):
-        """Given local inds of cell, branch, and comp, return the global comp index."""
-        global_ind = (
-            self.cumsum_nbranches[cell_inds] + branch_inds
-        ) * self.nseg + comp_inds
-        return global_ind.astype(int)
 
 
 class View:

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1416,9 +1416,7 @@ class Module(ABC):
             np.isnan(self.xyzr[branch_ind][:, dims])
         ), "No coordinates available. Use `vis(detail='point')` or run `.compute_xyz()` before running `.vis()`."
 
-        comp_fraction = loc_of_index(
-            comp_ind, branch_ind, self.cumsum_nseg, self.nseg_per_branch
-        )
+        comp_fraction = loc_of_index(comp_ind, self.cumsum_nseg)
         coords = self.xyzr[branch_ind]
         interpolated_xyz = interpolate_xyz(comp_fraction, coords)
 
@@ -1986,7 +1984,7 @@ class View:
         """
         idxs = self.view.global_branch_index.unique()
         if self.__class__.__name__ == "CompartmentView":
-            loc = loc_of_index(self.view.comp_index, self.pointer.nseg)
+            loc = loc_of_index(self.view.comp_index, self.pointer.cumsum_nseg)
             return list(interpolate_xyz(loc, self.pointer.xyzr[idxs[0]]))
         else:
             return [self.pointer.xyzr[i] for i in idxs]
@@ -2012,8 +2010,17 @@ class View:
         if is_new:  # synapse is not known
             self._update_synapse_state_names(synapse_type)
 
-        post_loc = loc_of_index(post_rows["comp_index"].to_numpy(), self.pointer.nseg)
-        pre_loc = loc_of_index(pre_rows["comp_index"].to_numpy(), self.pointer.nseg)
+        post_loc = loc_of_index(
+            post_rows["comp_index"].to_numpy(),
+            self.pointer.nseg_per_branch[post_rows["global_branch_index"].to_numpy()],
+        )
+        pre_loc = loc_of_index(
+            pre_rows["comp_index"].to_numpy(),
+            self.pointer.nseg_per_branch[pre_rows["global_branch_index"].to_numpy()],
+        )
+
+        print("post_rows", len(post_rows))
+        print("pre_rows", len(pre_rows))
 
         # Define new synapses. Each row is one synapse.
         new_rows = dict(

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -120,7 +120,10 @@ class CompartmentView(View):
             assert (
                 loc >= 0.0 and loc <= 1.0
             ), "Compartments must be indexed by a continuous value between 0 and 1."
-        index = index_of_loc(0, loc, self.pointer.nseg) if loc != "all" else "all"
+        branch_ind = np.unique(self.view["global_branch_index"].to_numpy())
+        nseg_of_branches = self.pointer.nseg_per_branch[branch_ind]
+        print("nseg_of_branches", nseg_of_branches)
+        index = index_of_loc(loc, nseg_of_branches) if loc != "all" else "all"
         view = self(index)
         view._has_been_called = True
         return view
@@ -137,13 +140,15 @@ class CompartmentView(View):
         start_branch = self.view["global_branch_index"].item()
         start_comp = self.view["comp_index"].item()
         start_xyz = interpolate_xyz(
-            loc_of_index(start_comp, self.pointer.nseg), self.pointer.xyzr[start_branch]
+            loc_of_index(start_comp, self.pointer.cumsum_nseg),
+            self.pointer.xyzr[start_branch],
         )
 
         end_branch = endpoint.view["global_branch_index"].item()
         end_comp = endpoint.view["comp_index"].item()
         end_xyz = interpolate_xyz(
-            loc_of_index(end_comp, self.pointer.nseg), self.pointer.xyzr[end_branch]
+            loc_of_index(end_comp, self.pointer.cumsum_nseg),
+            self.pointer.xyzr[end_branch],
         )
 
         return np.sqrt(np.sum((start_xyz - end_xyz) ** 2))

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -122,7 +122,6 @@ class CompartmentView(View):
             ), "Compartments must be indexed by a continuous value between 0 and 1."
         branch_ind = np.unique(self.view["global_branch_index"].to_numpy())
         nseg_of_branches = self.pointer.nseg_per_branch[branch_ind]
-        print("nseg_of_branches", nseg_of_branches)
         index = index_of_loc(loc, nseg_of_branches) if loc != "all" else "all"
         view = self(index)
         view._has_been_called = True

--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -213,9 +213,15 @@ def index_of_loc(branch_ind: int, loc: float, nseg_per_branch: int) -> int:
     return branch_ind * nseg + ind_along_branch
 
 
-def loc_of_index(global_comp_index, nseg):
+def loc_of_index(
+    global_comp_index: jnp.ndarray,
+    global_branch_index: jnp.ndarray,
+    cumsum_nseg_per_branch: jnp.ndarray,
+    nseg_per_branch: jnp.ndarray,
+) -> jnp.ndarray:
     """Return location corresponding to index."""
-    index = global_comp_index % nseg
+    index = global_comp_index - cumsum_nseg_per_branch[global_branch_index]
+    nseg = nseg_per_branch[global_branch_index]
     possible_locs = np.linspace(0.5 / nseg, 1 - 0.5 / nseg, nseg)
     return possible_locs[index]
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -55,7 +55,7 @@ def test_connect():
     connect(net2[1, 0], net2[2, 0], TestSynapse())
 
     # test after all connections are made, to catch "overwritten" connections
-    get_comps = lambda locs: [index_of_loc(0, idx, net2.nseg) for idx in locs]
+    get_comps = lambda locs: [index_of_loc(idx, net2.nseg) for idx in locs]
 
     # check if all connections are made correctly
     first_set_edges = net2.edges.iloc[:8]


### PR DESCRIPTION
This PR contains final fixes for having heterogenous numbers of compartments in different branches:

1) Fix for `._scatter()` for plotting
2) Fix for computing `xyzr` in `._update_nodes_with_xyz()`