### PR TITLE
Fixups for having heterogenous numbers of compartments in each branch

### DIFF
--- a/jaxley/connect.py
+++ b/jaxley/connect.py
@@ -136,9 +136,7 @@ def sparse_connect(
     post_rows = post_cell_view.view.loc[global_post_indices]
 
     # Pre-synapse is at the zero-eth branch and zero-eth compartment.
-    idcs_to_zero = np.zeros_like(num_pre)
-    get_global_idx = pre_cell_view.pointer._local_inds_to_global
-    global_pre_indices = get_global_idx(pre_syn_neurons, idcs_to_zero, idcs_to_zero)
+    global_pre_indices = pre_cell_view.pointer._cumsum_nseg_per_cell[pre_syn_neurons]
     pre_rows = pre_cell_view.view.loc[global_pre_indices]
 
     pre_cell_view._append_multiple_synapses(pre_rows, post_rows, synapse_type)
@@ -182,9 +180,8 @@ def connectivity_matrix_connect(
     ]
     post_rows = post_cell_view.view.loc[global_post_indices]
 
-    idcs_to_zero = np.zeros_like(from_idx)
-    get_global_idx = post_cell_view.pointer._local_inds_to_global
-    global_pre_indices = get_global_idx(pre_cell_inds, idcs_to_zero, idcs_to_zero)
+    # Pre-synapse is at the zero-eth branch and zero-eth compartment.
+    global_pre_indices = pre_cell_view.pointer._cumsum_nseg_per_cell[pre_cell_inds]
     pre_rows = pre_cell_view.view.loc[global_pre_indices]
 
     pre_cell_view._append_multiple_synapses(pre_rows, post_rows, synapse_type)

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -12,6 +12,7 @@ import pandas as pd
 from jaxley.modules.base import GroupView, Module, View
 from jaxley.modules.compartment import Compartment, CompartmentView
 from jaxley.utils.cell_utils import compute_children_and_parents
+from jaxley.utils.misc_utils import cumsum_leading_zero
 from jaxley.utils.solver_utils import comp_edges_to_indices
 
 
@@ -61,6 +62,7 @@ class Branch(Module):
         self.total_nbranches = 1
         self.nbranches_per_cell = [1]
         self.cumsum_nbranches = jnp.asarray([0, 1])
+        self.cumsum_nseg = cumsum_leading_zero(self.nseg_per_branch)
 
         # Indexing.
         self.nodes = pd.concat([c.nodes for c in compartment_list], ignore_index=True)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,7 +3,7 @@
 
 import jax
 
-from jaxley.utils.cell_utils import index_of_loc
+from jaxley.utils.cell_utils import local_index_of_loc
 
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_platform_name", "cpu")
@@ -55,7 +55,9 @@ def test_connect():
     connect(net2[1, 0], net2[2, 0], TestSynapse())
 
     # test after all connections are made, to catch "overwritten" connections
-    get_comps = lambda locs: [index_of_loc(0, idx, net2.nseg) for idx in locs]
+    get_comps = lambda locs: [
+        local_index_of_loc(loc, 0, net2.nseg_per_branch) for loc in locs
+    ]
 
     # check if all connections are made correctly
     first_set_edges = net2.edges.iloc[:8]

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -67,12 +67,10 @@ def test_subclassing_groups_net_set_equivalence():
     net1.excitatory.cell([0, 3]).branch(0).comp("all").set("radius", 0.14)
     net1.excitatory.cell([0, 5]).branch(1).comp("all").set("length", 0.16)
     net1.excitatory.cell("all").branch(1).comp(2).set("axial_resistivity", 1100.0)
-    net1.excitatory.cell("all").branch(1).loc(0.0).set("axial_resistivity", 1300.0)
 
     net2.cell([0, 3]).branch(0).comp("all").set("radius", 0.14)
     net2.cell([0, 5]).branch(1).comp("all").set("length", 0.16)
     net2.cell([0, 3, 5]).branch(1).comp(2).set("axial_resistivity", 1100.0)
-    net2.cell([0, 3, 5]).branch(1).loc(0.0).set("axial_resistivity", 1300.0)
 
     assert all(net1.nodes == net2.nodes)
 


### PR DESCRIPTION
This PR contains final fixes for having heterogenous numbers of compartments in different branches. It does the following things:
- update `index_of_loc`
- update `loc_of_index`
- remove `_local_inds_to_global` (which could easily be replaced in the __one__ place where it was used)

Replaces #439 