### PR TITLE
Reduce warnings

### DIFF
--- a/jaxley/synapses/test.py
+++ b/jaxley/synapses/test.py
@@ -14,6 +14,8 @@ class TestSynapse(Synapse):
     Compute syanptic current and update synapse state for a test synapse.
     """
 
+    __test__ = False # Not a unit test - pytest ignores
+
     def __init__(self, name: Optional[str] = None):
         super().__init__(name)
         prefix = self._name

--- a/jaxley/synapses/test.py
+++ b/jaxley/synapses/test.py
@@ -14,7 +14,7 @@ class TestSynapse(Synapse):
     Compute syanptic current and update synapse state for a test synapse.
     """
 
-    __test__ = False # Not a unit test - pytest ignores
+    __test__ = False  # Not a unit test - pytest ignores
 
     def __init__(self, name: Optional[str] = None):
         super().__init__(name)

--- a/jaxley/utils/jax_utils.py
+++ b/jaxley/utils/jax_utils.py
@@ -58,7 +58,7 @@ def nested_checkpoint_scan(
         new_shape = tuple(nested_lengths) + x.shape[1:]
         return x.reshape(new_shape)
 
-    sub_xs = jax.tree_map(nested_reshape, xs)
+    sub_xs = jax.tree_util.tree_map(nested_reshape, xs)
     return _inner_nested_scan(f, init, sub_xs, nested_lengths, scan_fn, checkpoint_fn)
 
 
@@ -72,5 +72,5 @@ def _inner_nested_scan(f, init, xs, lengths, scan_fn, checkpoint_fn):
         return _inner_nested_scan(f, carry, xs, lengths[1:], scan_fn, checkpoint_fn)
 
     carry, out = scan_fn(sub_scans, init, xs, lengths[0])
-    stacked_out = jax.tree_map(jnp.concatenate, out)
+    stacked_out = jax.tree_util.tree_map(jnp.concatenate, out)
     return carry, stacked_out

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -99,12 +99,12 @@ def test_subclassing_groups_net_make_trainable_equivalence():
     net1.excitatory.scope("global").cell("all").scope("local").branch(1).comp(
         2
     ).make_trainable("axial_resistivity")
-    params1 = jnp.concatenate(jax.tree_flatten(net1.get_parameters())[0])
+    params1 = jnp.concatenate(jax.tree_util.tree_flatten(net1.get_parameters())[0])
 
     net2.cell([0, 3]).branch(0).make_trainable("radius")
     net2.cell([0, 5]).branch(1).comp("all").make_trainable("length")
     net2.cell([0, 3, 5]).branch(1).comp(2).make_trainable("axial_resistivity")
-    params2 = jnp.concatenate(jax.tree_flatten(net2.get_parameters())[0])
+    params2 = jnp.concatenate(jax.tree_util.tree_flatten(net2.get_parameters())[0])
     assert jnp.array_equal(params1, params2)
 
     for inds1, inds2 in zip(
@@ -128,13 +128,13 @@ def test_subclassing_groups_net_lazy_indexing_make_trainable_equivalence():
     net1.excitatory.cell([0, 3]).branch(0).make_trainable("radius")
     net1.excitatory.cell([0, 5]).branch(1).comp("all").make_trainable("length")
     net1.excitatory.cell("all").branch(1).comp(2).make_trainable("axial_resistivity")
-    params1 = jnp.concatenate(jax.tree_flatten(net1.get_parameters())[0])
+    params1 = jnp.concatenate(jax.tree_util.tree_flatten(net1.get_parameters())[0])
 
     # The following lines are made possible by PR #324.
     net2.excitatory[[0, 3], 0].make_trainable("radius")
     net2.excitatory[[0, 5], 1, :].make_trainable("length")
     net2.excitatory[:, 1, 2].make_trainable("axial_resistivity")
-    params2 = jnp.concatenate(jax.tree_flatten(net2.get_parameters())[0])
+    params2 = jnp.concatenate(jax.tree_util.tree_flatten(net2.get_parameters())[0])
 
     assert jnp.array_equal(params1, params2)
 


### PR DESCRIPTION
# Fixing deprecation warnings
We change all:
- jax.tree_map -> jax.tree_util.tree_map
- Pytest ignores TestSynapse

Note: We do not change use of `a_max` in `jnp.clip`, because this require jax>0.4.30 (which is too recent yet)