### PR TITLE
Write trainables to module

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1053,13 +1053,16 @@ class Module(ABC):
         Args:
             trainable_params: The trainable parameters returned by `get_parameters()`.
         """
-        # We do not support synapse views. Why? `jaxedges` does not have any NaN
+        # We do not support views. Why? `jaxedges` does not have any NaN
         # elements, whereas edges does. Because of this, we already need special
         # treatment to make this function work, and it would be an even bigger hassle
         # if we wanted to support this.
-        assert len(self.base.edges) == len(self._edges_in_view), (
-            "`write_trainables` is not supported for synapse views."
-        )
+        assert self.__class__.__name__ in [
+            "Compartment",
+            "Branch",
+            "Cell",
+            "Network",
+        ], "Only supports modules."
 
         # We could also implement this without casting the module to jax.
         # However, I think it allows us to reuse as much code as possible and it avoids
@@ -1079,7 +1082,7 @@ class Module(ABC):
             key = parameter["key"]
             if key in self.base.nodes.columns:
                 vals_to_set = all_params if key in all_params.keys() else all_states
-                self.base.nodes.loc[self._nodes_in_view, key] = vals_to_set[key][self._nodes_in_view]
+                self.base.nodes[key] = vals_to_set[key]
 
         # `jaxedges` contains only non-Nan elements. This is unlike the channels where
         # we allow parameter sharing.

--- a/tests/test_make_trainable.py
+++ b/tests/test_make_trainable.py
@@ -5,6 +5,7 @@ import jax
 
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_platform_name", "cpu")
+from copy import copy
 
 import jax.numpy as jnp
 import numpy as np
@@ -475,9 +476,16 @@ def test_write_trainables():
 
     # Test whether voltages match.
     v1 = jx.integrate(net, params=params)
+
+    previous_nodes = copy(net.nodes)
+    previous_edges = copy(net.edges)
     net.write_trainables(params)
     v2 = jx.integrate(net)
     assert np.max(np.abs(v1 - v2)) < 1e-8
+
+    # Test whether nodes and edges actually changed.
+    assert not net.nodes.equals(previous_nodes)
+    assert not net.edges.equals(previous_edges)
 
     # Test whether `View` raises with `write_trainables()`.
     with pytest.raises(AssertionError):

--- a/tests/test_make_trainable.py
+++ b/tests/test_make_trainable.py
@@ -432,11 +432,11 @@ def test_write_trainables():
     net = jx.Network([cell for _ in range(2)])
     connect(
         net.cell(0).branch(0).loc(0.9),
-        net.cell(0).branch(1).loc(0.1),
+        net.cell(1).branch(1).loc(0.1),
         IonotropicSynapse(),
     )
     connect(
-        net.cell(0).branch(0).loc(0.1),
+        net.cell(1).branch(0).loc(0.1),
         net.cell(0).branch(1).loc(0.3),
         TestSynapse(),
     )
@@ -446,8 +446,8 @@ def test_write_trainables():
         TestSynapse(),
     )
     connect(
-        net.cell(0).branch(0).loc(0.6),
-        net.cell(0).branch(1).loc(0.9),
+        net.cell(1).branch(0).loc(0.6),
+        net.cell(1).branch(1).loc(0.9),
         IonotropicSynapse(),
     )
     net.insert(HH())
@@ -479,14 +479,10 @@ def test_write_trainables():
     v2 = jx.integrate(net)
     assert np.max(np.abs(v1 - v2)) < 1e-8
 
-    # Test whether `View` works with `write_trainables()`.
-    # Again manually modify the parameters.
-    for p in params:
-        for key in p:
-            p[key] = p[key].at[:].set(np.random.rand())
-
-    net.cell(0).write_trainables(params)
+    # Test whether `View` raises with `write_trainables()`.
+    with pytest.raises(AssertionError):
+        net.cell(0).write_trainables(params)
 
     # Test whether synapse view raises an error.
-    with pytest.xfail(AssertionError()):
+    with pytest.raises(AssertionError):
         net.select(edges=[0, 2, 3]).write_trainables(params)


### PR DESCRIPTION
This PR introduces a `write_trainables()` which adds the trainables to the `.nodes` and `.edges` such that they can be used for plotting, printing,...

```python
net.make_trainable("radius")
params = net.get_parameters()

net.write_trainables(params)
```

Closes #356 