### PR TITLE
Simpler edge indexing

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -32,7 +32,7 @@ from jaxley.utils.cell_utils import (
     interpolate_xyz,
     loc_of_index,
     params_to_pstate,
-    query_channel_states_and_params,
+    query_states_and_params,
     v_interp,
 )
 from jaxley.utils.debug_solver import compute_morphology_indices
@@ -712,16 +712,15 @@ class Module(ABC):
         """
         jaxnodes = self.base.jaxnodes = {}
         nodes = self.base.nodes.to_dict(orient="list")
-        
+
         jaxedges = self.base.jaxedges = {}
         edges = self.base.edges.to_dict(orient="list")
-        edges.pop("type") # drop since column type is string
-        
+        edges.pop("type")  # drop since column type is string
+
         for jax_array, params in zip([jaxnodes, jaxedges], [nodes, edges]):
             for key, value in params.items():
                 inds = jnp.arange(len(value))
                 jax_array[key] = jnp.asarray(value)[inds]
-
 
     def show(
         self,
@@ -1230,17 +1229,6 @@ class Module(ABC):
             inds = parameter["indices"]
             set_param = parameter["val"]
 
-            # This is needed since SynapseViews worked differently before.
-            # This mimics the old behaviour and tranformes the new indices
-            # to the old indices.
-            # TODO FROM #447: Longterm this should be gotten rid of.
-            # Instead edges should work similar to nodes (would also allow for
-            # param sharing).
-            synapse_inds = self.base.edges.groupby("type").rank()["global_edge_index"]
-            synapse_inds = (synapse_inds.astype(int) - 1).to_numpy()
-            if key in self.base.synapse_param_names:
-                inds = synapse_inds[inds]
-
             if key in params:  # Only parameters, not initial states.
                 # `inds` is of shape `(num_params, num_comps_per_param)`.
                 # `set_param` is of shape `(num_params,)`
@@ -1347,10 +1335,10 @@ class Module(ABC):
 
             channel_param_names = list(channel.channel_params.keys())
             channel_state_names = list(channel.channel_states.keys())
-            channel_states = query_channel_states_and_params(
+            channel_states = query_states_and_params(
                 states, channel_state_names, channel_indices
             )
-            channel_params = query_channel_states_and_params(
+            channel_params = query_states_and_params(
                 params, channel_param_names, channel_indices
             )
 
@@ -1839,35 +1827,33 @@ class Module(ABC):
     ) -> Dict[str, jnp.ndarray]:
         """One integration step of the channels."""
         voltages = states["v"]
+        morph_params = ["radius", "length", "axial_resistivity", "capacitance"]
 
         # Update states of the channels.
-        indices = channel_nodes["global_comp_index"].to_numpy()
         for channel in channels:
-            channel_param_names = list(channel.channel_params)
-            channel_param_names += [
-                "radius",
-                "length",
-                "axial_resistivity",
-                "capacitance",
-            ]
-            channel_state_names = list(channel.channel_states)
-            channel_state_names += self.membrane_current_names
-            channel_indices = indices[channel_nodes[channel._name].astype(bool)]
+            has_channel = channel_nodes[channel._name]
+            channel_inds = channel_nodes.loc[
+                has_channel, "global_comp_index"
+            ].to_numpy()
 
-            channel_params = query_channel_states_and_params(
-                params, channel_param_names, channel_indices
+            channel_param_names = list(channel.channel_params) + morph_params
+            channel_params = query_states_and_params(
+                params, channel_param_names, channel_inds
             )
-            channel_states = query_channel_states_and_params(
-                states, channel_state_names, channel_indices
+            channel_state_names = (
+                list(channel.channel_states) + self.membrane_current_names
+            )
+            channel_states = query_states_and_params(
+                states, channel_state_names, channel_inds
             )
 
             states_updated = channel.update_states(
-                channel_states, delta_t, voltages[channel_indices], channel_params
+                channel_states, delta_t, voltages[channel_inds], channel_params
             )
             # Rebuild state. This has to be done within the loop over channels to allow
             # multiple channels which modify the same state.
             for key, val in states_updated.items():
-                states[key] = states[key].at[channel_indices].set(val)
+                states[key] = states[key].at[channel_inds].set(val)
 
         return states
 
@@ -1884,53 +1870,53 @@ class Module(ABC):
         This is also updates `state` because the `state` also contains the current.
         """
         voltages = states["v"]
+        morph_params = ["radius", "length", "axial_resistivity"]
 
         # Compute current through channels.
-        voltage_terms = jnp.zeros_like(voltages)
-        constant_terms = jnp.zeros_like(voltages)
+        zeros = jnp.zeros_like(voltages)
+        voltage_terms = zeros
+        constant_terms = zeros
         # Run with two different voltages that are `diff` apart to infer the slope and
         # offset.
         diff = 1e-3
 
-        current_states = {}
-        for name in self.membrane_current_names:
-            current_states[name] = jnp.zeros_like(voltages)
-
+        current_states = {name: zeros for name in self.membrane_current_names}
         for channel in channels:
             name = channel._name
-            channel_param_names = list(channel.channel_params.keys())
-            channel_state_names = list(channel.channel_states.keys())
-            indices = channel_nodes.loc[channel_nodes[name]][
+            channel_inds = channel_nodes.loc[channel_nodes[name]][
                 "global_comp_index"
             ].to_numpy()
 
-            channel_params = {}
-            for p in channel_param_names:
-                channel_params[p] = params[p][indices]
-            channel_params["radius"] = params["radius"][indices]
-            channel_params["length"] = params["length"][indices]
-            channel_params["axial_resistivity"] = params["axial_resistivity"][indices]
+            channel_params = query_states_and_params(
+                params, list(channel.channel_params) + morph_params, channel_inds
+            )
+            channel_states = query_states_and_params(
+                states, channel.channel_states, channel_inds
+            )
 
-            channel_states = {}
-            for s in channel_state_names:
-                channel_states[s] = states[s][indices]
+            v_and_perturbed = jnp.stack(
+                [voltages[channel_inds], voltages[channel_inds] + diff]
+            )
 
-            v_and_perturbed = jnp.stack([voltages[indices], voltages[indices] + diff])
             membrane_currents = vmap(channel.compute_current, in_axes=(None, 0, None))(
                 channel_states, v_and_perturbed, channel_params
             )
+
+            # Split into voltage and constant terms.
             voltage_term = (membrane_currents[1] - membrane_currents[0]) / diff
-            constant_term = membrane_currents[0] - voltage_term * voltages[indices]
+            constant_term = membrane_currents[0] - voltage_term * voltages[channel_inds]
 
             # * 1000 to convert from mA/cm^2 to uA/cm^2.
-            voltage_terms = voltage_terms.at[indices].add(voltage_term * 1000.0)
-            constant_terms = constant_terms.at[indices].add(-constant_term * 1000.0)
+            voltage_terms = voltage_terms.at[channel_inds].add(voltage_term * 1000.0)
+            constant_terms = constant_terms.at[channel_inds].add(
+                -constant_term * 1000.0
+            )
 
             # Save the current (for the unperturbed voltage) as a state that will
             # also be passed to the state update.
             current_states[channel.current_name] = (
                 current_states[channel.current_name]
-                .at[indices]
+                .at[channel_inds]
                 .add(membrane_currents[0])
             )
 
@@ -1938,7 +1924,6 @@ class Module(ABC):
         # recorded and used by `Channel.update_states()`.
         for name in self.membrane_current_names:
             states[name] = current_states[name]
-
         return states, (voltage_terms, constant_terms)
 
     def _step_synapse(

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -710,22 +710,18 @@ class Module(ABC):
         they can be processed on GPU/TPU and such that the simulation can be
         differentiated. `.to_jax()` copies the `.nodes` to `.jaxnodes`.
         """
-        self.base.jaxnodes = {}
-        for key, value in self.base.nodes.to_dict(orient="list").items():
-            inds = jnp.arange(len(value))
-            self.base.jaxnodes[key] = jnp.asarray(value)[inds]
-
-        # `jaxedges` contains only parameters (no indices).
-        # `jaxedges` contains only non-Nan elements. This is unlike the channels where
-        # we allow parameter sharing.
-        self.base.jaxedges = {}
+        jaxnodes = self.base.jaxnodes = {}
+        nodes = self.base.nodes.to_dict(orient="list")
+        
+        jaxedges = self.base.jaxedges = {}
         edges = self.base.edges.to_dict(orient="list")
-        for i, synapse in enumerate(self.base.synapses):
-            condition = np.asarray(edges["type_ind"]) == i
-            for key in synapse.synapse_params:
-                self.base.jaxedges[key] = jnp.asarray(np.asarray(edges[key])[condition])
-            for key in synapse.synapse_states:
-                self.base.jaxedges[key] = jnp.asarray(np.asarray(edges[key])[condition])
+        edges.pop("type") # drop since column type is string
+        
+        for jax_array, params in zip([jaxnodes, jaxedges], [nodes, edges]):
+            for key, value in params.items():
+                inds = jnp.arange(len(value))
+                jax_array[key] = jnp.asarray(value)[inds]
+
 
     def show(
         self,
@@ -1119,19 +1115,11 @@ class Module(ABC):
         # Loop only over the keys in `pstate` to avoid unnecessary computation.
         for parameter in pstate:
             key = parameter["key"]
+            vals_to_set = all_params if key in all_params.keys() else all_states
             if key in self.base.nodes.columns:
-                vals_to_set = all_params if key in all_params.keys() else all_states
                 self.base.nodes[key] = vals_to_set[key]
-
-        # `jaxedges` contains only non-Nan elements. This is unlike the channels where
-        # we allow parameter sharing.
-        edges = self.base.edges.to_dict(orient="list")
-        for i, synapse in enumerate(self.base.synapses):
-            condition = np.asarray(edges["type_ind"]) == i
-            for key in list(synapse.synapse_params.keys()):
-                self.base.edges.loc[condition, key] = all_params[key]
-            for key in list(synapse.synapse_states.keys()):
-                self.base.edges.loc[condition, key] = all_states[key]
+            if key in self.base.edges.columns:
+                self.base.edges[key] = vals_to_set[key]
 
     def distance(self, endpoint: "View") -> float:
         """Return the direct distance between two compartments.

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -20,6 +20,7 @@ from jaxley.utils.cell_utils import (
     convert_point_process_to_distributed,
     loc_of_index,
     merge_cells,
+    query_states_and_params,
 )
 from jaxley.utils.misc_utils import concat_and_ignore_empty, cumsum_leading_zero
 from jaxley.utils.solver_utils import (
@@ -261,30 +262,21 @@ class Network(Module):
     ) -> Dict:
         voltages = states["v"]
 
-        grouped_syns = edges.groupby("type", sort=False, group_keys=False)
-        pre_syn_inds = grouped_syns["global_pre_comp_index"].apply(list)
-        post_syn_inds = grouped_syns["global_post_comp_index"].apply(list)
-        synapse_names = list(grouped_syns.indices.keys())
+        for i, group in edges.groupby("type_ind"):
+            synapse = syn_channels[i]
+            pre_inds = group["global_pre_comp_index"].to_numpy()
+            post_inds = group["global_post_comp_index"].to_numpy()
+            edge_inds = group.index.to_numpy()
 
-        for i, synapse_type in enumerate(syn_channels):
-            assert (
-                synapse_names[i] == synapse_type._name
-            ), "Mixup in the ordering of synapses. Please create an issue on Github."
-            synapse_param_names = list(synapse_type.synapse_params.keys())
-            synapse_state_names = list(synapse_type.synapse_states.keys())
-
-            synapse_params = {}
-            for p in synapse_param_names:
-                synapse_params[p] = params[p]
-            synapse_states = {}
-            for s in synapse_state_names:
-                synapse_states[s] = states[s]
-
-            pre_inds = np.asarray(pre_syn_inds[synapse_names[i]])
-            post_inds = np.asarray(post_syn_inds[synapse_names[i]])
+            synapse_params = query_states_and_params(
+                params, synapse.synapse_params, edge_inds
+            )
+            synapse_states = query_states_and_params(
+                states, synapse.synapse_states, edge_inds
+            )
 
             # State updates.
-            states_updated = synapse_type.update_states(
+            states_updated = synapse.update_states(
                 synapse_states,
                 delta_t,
                 voltages[pre_inds],
@@ -292,9 +284,10 @@ class Network(Module):
                 synapse_params,
             )
 
-            # Rebuild state.
+            # Rebuild state. This has to be done within the loop over channels to allow
+            # multiple channels which modify the same state.
             for key, val in states_updated.items():
-                states[key] = val
+                states[key] = states[key].at[group.index.to_numpy()].set(val)
 
         return states
 
@@ -308,43 +301,37 @@ class Network(Module):
     ) -> Tuple[Dict, Tuple[jnp.ndarray, jnp.ndarray]]:
         voltages = states["v"]
 
-        grouped_syns = edges.groupby("type", sort=False, group_keys=False)
-        pre_syn_inds = grouped_syns["global_pre_comp_index"].apply(list)
-        post_syn_inds = grouped_syns["global_post_comp_index"].apply(list)
-        synapse_names = list(grouped_syns.indices.keys())
-
-        syn_voltage_terms = jnp.zeros_like(voltages)
-        syn_constant_terms = jnp.zeros_like(voltages)
+        # Compute current through synapses.
+        zeros = jnp.zeros_like(voltages)
+        syn_voltage_terms = zeros
+        syn_constant_terms = zeros
         # Run with two different voltages that are `diff` apart to infer the slope and
         # offset.
         diff = 1e-3
-        for i, synapse_type in enumerate(syn_channels):
-            assert (
-                synapse_names[i] == synapse_type._name
-            ), "Mixup in the ordering of synapses. Please create an issue on Github."
-            synapse_param_names = list(synapse_type.synapse_params.keys())
-            synapse_state_names = list(synapse_type.synapse_states.keys())
 
-            synapse_params = {}
-            for p in synapse_param_names:
-                synapse_params[p] = params[p]
-            synapse_states = {}
-            for s in synapse_state_names:
-                synapse_states[s] = states[s]
+        synapse_current_states = {f"{s._name}_current": zeros for s in syn_channels}
+        for i, group in edges.groupby("type_ind"):
+            synapse = syn_channels[i]
+            pre_inds = group["global_pre_comp_index"].to_numpy()
+            post_inds = group["global_post_comp_index"].to_numpy()
+            edge_inds = group.index.to_numpy()
 
-            # Get pre and post indexes of the current synapse type.
-            pre_inds = np.asarray(pre_syn_inds[synapse_names[i]])
-            post_inds = np.asarray(post_syn_inds[synapse_names[i]])
+            synapse_params = query_states_and_params(
+                params, synapse.synapse_params, edge_inds
+            )
+            synapse_states = query_states_and_params(
+                states, synapse.synapse_states, edge_inds
+            )
 
-            # Compute slope and offset of the current through every synapse.
             pre_v_and_perturbed = jnp.stack(
                 [voltages[pre_inds], voltages[pre_inds] + diff]
             )
             post_v_and_perturbed = jnp.stack(
                 [voltages[post_inds], voltages[post_inds] + diff]
             )
+
             synapse_currents = vmap(
-                synapse_type.compute_current, in_axes=(None, 0, 0, None)
+                synapse.compute_current, in_axes=(None, 0, 0, None)
             )(
                 synapse_states,
                 pre_v_and_perturbed,
@@ -370,14 +357,22 @@ class Network(Module):
                 voltage_term,
                 constant_term,
             )
-            syn_voltage_terms += gathered_syn_currents[0]
-            syn_constant_terms -= gathered_syn_currents[1]
 
-            # Add the synaptic currents through every compartment as state.
-            # `post_syn_currents` is a `jnp.ndarray` of as many elements as there are
-            # compartments in the network.
-            # `[0]` because we only use the non-perturbed voltage.
-            states[f"{synapse_type._name}_current"] = synapse_currents[0]
+            syn_voltage_terms = syn_voltage_terms.at[:].add(gathered_syn_currents[0])
+            syn_constant_terms = syn_constant_terms.at[:].add(-gathered_syn_currents[1])
+
+            # Save the current (for the unperturbed voltage) as a state that will
+            # also be passed to the state update.
+            synapse_current_states[f"{synapse._name}_current"] = (
+                synapse_current_states[f"{synapse._name}_current"]
+                .at[edge_inds]
+                .add(synapse_currents_dist[0])
+            )
+
+        # Copy the currents into the `state` dictionary such that they can be
+        # recorded and used by `Channel.update_states()`.
+        for name in [s._name for s in self.synapses]:
+            states[f"{name}_current"] = synapse_current_states[f"{name}_current"]
 
         return states, (syn_voltage_terms, syn_constant_terms)
 

--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -398,7 +398,7 @@ def group_and_sum(
     return group_sums
 
 
-def query_channel_states_and_params(d, keys, idcs):
+def query_states_and_params(d, keys, idcs):
     """Get dict with subset of keys and values from d.
 
     This is used to restrict a dict where every item contains __all__ states to only

--- a/tests/test_make_trainable.py
+++ b/tests/test_make_trainable.py
@@ -130,9 +130,9 @@ def test_diverse_synapse_types():
     assert np.all(all_parameters["length"] == 10.0)
     assert np.all(all_parameters["axial_resistivity"] == 5000.0)
     assert np.all(all_parameters["IonotropicSynapse_gS"][0] == 2.2)
-    assert np.all(all_parameters["IonotropicSynapse_gS"][1] == 2.2)
-    assert np.all(all_parameters["TestSynapse_gC"][0] == 3.3)
-    assert np.all(all_parameters["TestSynapse_gC"][1] == 4.4)
+    assert np.all(all_parameters["IonotropicSynapse_gS"][2] == 2.2)
+    assert np.all(all_parameters["TestSynapse_gC"][1] == 3.3)
+    assert np.all(all_parameters["TestSynapse_gC"][3] == 4.4)
 
     # Add another trainable parameter and test again.
     net.IonotropicSynapse.edge(1).make_trainable("IonotropicSynapse_gS")
@@ -146,7 +146,7 @@ def test_diverse_synapse_types():
     pstate = params_to_pstate(params, net.indices_set_by_trainables)
     all_parameters = net.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
     assert np.all(all_parameters["IonotropicSynapse_gS"][0] == 2.2)
-    assert np.all(all_parameters["IonotropicSynapse_gS"][1] == 5.5)
+    assert np.all(all_parameters["IonotropicSynapse_gS"][2] == 5.5)
 
 
 def test_make_all_trainable_corresponds_to_set():


### PR DESCRIPTION
Currently synapse and channel parameters / states are handled differently. While channel params are referred to with global indices,  synapse params are referenced on a per synapse basis. This leads to very different implementations of synapse and channel updates. This PR makes the synapse indexing global, which simplifies several aspects of the code.