### PR TITLE
Connectivity_matrix_connect update

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -203,3 +203,17 @@ def test_connectivity_matrix_connect():
     comp_inds = nodes.loc[net.edges[cols].to_numpy().flatten()]
     cell_inds = comp_inds["global_cell_index"].to_numpy().reshape(-1, 2)
     assert np.all(cell_inds == incides_of_connected_cells)
+
+    net = jx.Network([cell for _ in range(4 * 4)])
+    connectivity_matrix_connect(
+        net[1:4], net[2:6], TestSynapse(), m_by_n_adjacency_matrix
+    )
+    assert len(net.edges.index) == 5
+    nodes = net.nodes.set_index("global_comp_index")
+    cols = ["global_pre_comp_index", "global_post_comp_index"]
+    comp_inds = nodes.loc[net.edges[cols].to_numpy().flatten()]
+    cell_inds = comp_inds["global_cell_index"].to_numpy().reshape(-1, 2)
+    # adjust the cell indices based on the view range passed
+    incides_of_connected_cells[:, 0] += 1
+    incides_of_connected_cells[:, 1] += 2
+    assert np.all(cell_inds == incides_of_connected_cells)


### PR DESCRIPTION
This PR resolves #486 so that views with global indices of different ranges can be used to connect cells with an adjacency matrix (and adds a test). 

I also removed the random selection of compartments on the post synaptic cell because I don't quite see the benefit to doing this as opposed to just using the first compartment of the first branch, and the random selection in list comprehension was really slowing down my building of large networks. This being said, I would be interested in having connectivity_matrix_connect take a matrix (num pre comps x num post comps) instead of (num pre cells x num post cells) for more fine control of the connectivity... I can open another issue about this as enhancement. 