### PR TITLE
Add support for boolean indexing of cells/branches/comps

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -395,9 +395,11 @@ class Module(ABC):
 
         idx = np.arange(len(self.base.nodes))[idx] if isinstance(idx, slice) else idx
         if idx.dtype == bool:
-            which_idx = len(idx) == np.array(self.shape)
+            shape = (*self.shape, len(self.edges))
+            which_idx = len(idx) == np.array(shape)
             assert np.any(which_idx), "Index not matching num of cells/branches/comps."
-            idx = np.arange(self.shape[np.where(which_idx)[0][0]])[idx]
+            dim = shape[np.where(which_idx)[0][0]]
+            idx = np.arange(dim)[idx]
         assert isinstance(idx, np.ndarray), "Invalid type"
         assert idx.dtype in [np_dtype, bool], "Invalid dtype"
         return idx.reshape(-1)

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -395,9 +395,9 @@ class Module(ABC):
         num = len(self._cells_in_view) if childview == "cell" else num
 
         idx = np.arange(num)[idx] if isinstance(idx, slice) else idx
-        idx = np.arange(num)[idx] if idx.dtype == bool else idx
         if is_str_all(idx):  # also asserts that the only allowed str == "all"
             return idx
+        idx = np.arange(num)[idx] if idx.dtype == bool else idx
         assert isinstance(idx, np.ndarray), "Invalid type"
         assert idx.dtype in [np_dtype, bool], "Invalid dtype"
         return idx.reshape(-1)

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -387,12 +387,19 @@ class Module(ABC):
         idx = np.array([], dtype=dtype) if idx is None else idx
         idx = np.array([idx]) if isinstance(idx, (dtype, np_dtype)) else idx
         idx = np.array(idx) if isinstance(idx, (list, range, pd.Index)) else idx
-        num_nodes = len(self._nodes_in_view)
-        idx = np.arange(num_nodes + 1)[idx] if isinstance(idx, slice) else idx
+
+        childviews = self._childviews()
+        childview = childviews[0] if len(childviews) > 0 else None
+        num = len(self._nodes_in_view)
+        num = len(self._branches_in_view) if childview == "branch" else num
+        num = len(self._cells_in_view) if childview == "cell" else num
+
+        idx = np.arange(num)[idx] if isinstance(idx, slice) else idx
+        idx = np.arange(num)[idx] if idx.dtype == bool else idx
         if is_str_all(idx):  # also asserts that the only allowed str == "all"
             return idx
         assert isinstance(idx, np.ndarray), "Invalid type"
-        assert idx.dtype == np_dtype, "Invalid dtype"
+        assert idx.dtype in [np_dtype, bool], "Invalid dtype"
         return idx.reshape(-1)
 
     def _set_controlled_by_param(self, key: str):

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -317,7 +317,7 @@ def test_view_supported_index_types(module):
         [0, 1, 2],
         np.array([0, 1, 2]),
         pd.Index([0, 1, 2]),
-        np.array([True, False, True]),
+        np.array([True, False, True] * 100)[: len(module.nodes)],
     ]
 
     # comp.comp is not allowed
@@ -330,9 +330,9 @@ def test_view_supported_index_types(module):
             assert module.comp(index), f"Failed for {type(index)}"
             assert View(module).comp(index), f"Failed for {type(index)}"
 
-            # for loc test float and list of floats
-            assert module.loc(0.0), "Failed for float"
-            assert module.loc([0.0, 0.5, 1.0]), "Failed for List[float]"
+        # for loc test float and list of floats
+        assert module.loc(0.0), "Failed for float"
+        assert module.loc([0.0, 0.5, 1.0]), "Failed for List[float]"
     else:
         with pytest.raises(AssertionError):
             module.comp(0)

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -301,9 +301,10 @@ def test_view_attrs(module: jx.Compartment | jx.Branch | jx.Cell | jx.Network):
 
 
 comp = jx.Compartment()
-branch = jx.Branch([comp] * 4)
-cell = jx.Cell([branch] * 4, parents=[-1, 0, 0, 0])
-net = jx.Network([cell] * 4)
+branch = jx.Branch(nseg=4)
+cell = jx.Cell([branch] * 5, parents=[-1, 0, 0, 1, 1])
+net = jx.Network([cell] * 2)
+connect(net[0, 0, :], net[1, 0, :], TestSynapse())
 
 
 @pytest.mark.parametrize("module", [comp, branch, cell, net])
@@ -317,18 +318,24 @@ def test_view_supported_index_types(module):
         [0, 1, 2],
         np.array([0, 1, 2]),
         pd.Index([0, 1, 2]),
-        np.array([True, False, True] * 100)[: len(module.nodes)],
+        np.array([True, False, True, False] * 100)[: len(module.nodes)],
     ]
 
     # comp.comp is not allowed
+    all_inds = module.nodes.index.to_numpy()
     if not isinstance(module, jx.Compartment):
         # `_reformat_index` should always return a np.ndarray
         for index in index_types:
             assert isinstance(
                 module._reformat_index(index), np.ndarray
             ), f"Failed for {type(index)}"
+
+            # test indexing into module and view
             assert module.comp(index), f"Failed for {type(index)}"
             assert View(module).comp(index), f"Failed for {type(index)}"
+
+            expected_inds = all_inds[index]
+            assert np.all(module.select(nodes=index).nodes.index == expected_inds)
 
         # for loc test float and list of floats
         assert module.loc(0.0), "Failed for float"
@@ -336,6 +343,12 @@ def test_view_supported_index_types(module):
     else:
         with pytest.raises(AssertionError):
             module.comp(0)
+
+    if isinstance(module, jx.Network):
+        all_inds = module.edges.index.to_numpy()
+        for index in index_types[:-1] + [np.array([True, False, True, False])]:
+            expected_inds = all_inds[index]
+            assert np.all(net.select(edges=index).edges.index == expected_inds)
 
 
 def test_select():

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -317,6 +317,7 @@ def test_view_supported_index_types(module):
         [0, 1, 2],
         np.array([0, 1, 2]),
         pd.Index([0, 1, 2]),
+        np.array([True, False, True]),
     ]
 
     # comp.comp is not allowed


### PR DESCRIPTION
This PR adds boolean indexing to Views. This is for convenience. Can be used to do stuff like:
```python
r_greater_1 = net.nodes.groupby("global_cell_index)["r"].mean() > 1
net[r_greater_1].nodes.vis()
# or
net.select(nodes=net.nodes["r"] > 1) # vs. net.select(nodes=net.nodes.index[net.nodes["r"] > 1])
```