### PR TITLE
[MRG] Make methods/attributes private

### DIFF
--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1434,7 +1434,7 @@ class Module(ABC):
             len(self.base._par_inds),
             self.base.child_belongs_to_branchpoint,
             self.base._par_inds,
-            self.base.child_inds,
+            self.base._child_inds,
             self.base.nseg,
             self.base.total_nbranches,
         )
@@ -1452,7 +1452,7 @@ class Module(ABC):
         self.base.debug_states["indptr"] = indptr
 
         self.base.debug_states["nseg"] = self.base.nseg
-        self.base.debug_states["child_inds"] = self.base.child_inds
+        self.base.debug_states["child_inds"] = self.base._child_inds
         self.base.debug_states["par_inds"] = self.base._par_inds
 
     def record(self, state: str = "v", verbose=True):
@@ -1815,7 +1815,7 @@ class Module(ABC):
                     "types": np.asarray(self._comp_edges["type"].to_list()),
                     "nseg_per_branch": self.nseg_per_branch,
                     "par_inds": self._par_inds,
-                    "child_inds": self.child_inds,
+                    "child_inds": self._child_inds,
                     "nbranches": self.total_nbranches,
                     "solver": voltage_solver,
                     "idx": self.solve_indexer,

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1432,7 +1432,7 @@ class Module(ABC):
         # For scipy and jax.scipy.
         row_and_col_inds = compute_morphology_indices(
             len(self.base._par_inds),
-            self.base.child_belongs_to_branchpoint,
+            self.base._child_belongs_to_branchpoint,
             self.base._par_inds,
             self.base._child_inds,
             self.base.nseg,

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1818,7 +1818,7 @@ class Module(ABC):
                     "child_inds": self._child_inds,
                     "nbranches": self.total_nbranches,
                     "solver": voltage_solver,
-                    "idx": self.solve_indexer,
+                    "idx": self._solve_indexer,
                     "debug_states": self.debug_states,
                 }
             )

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1431,9 +1431,9 @@ class Module(ABC):
         """
         # For scipy and jax.scipy.
         row_and_col_inds = compute_morphology_indices(
-            len(self.base.par_inds),
+            len(self.base._par_inds),
             self.base.child_belongs_to_branchpoint,
-            self.base.par_inds,
+            self.base._par_inds,
             self.base.child_inds,
             self.base.nseg,
             self.base.total_nbranches,
@@ -1453,7 +1453,7 @@ class Module(ABC):
 
         self.base.debug_states["nseg"] = self.base.nseg
         self.base.debug_states["child_inds"] = self.base.child_inds
-        self.base.debug_states["par_inds"] = self.base.par_inds
+        self.base.debug_states["par_inds"] = self.base._par_inds
 
     def record(self, state: str = "v", verbose=True):
         comp_states, edge_states = self._get_state_names()
@@ -1814,7 +1814,7 @@ class Module(ABC):
                     "sources": np.asarray(self._comp_edges["source"].to_list()),
                     "types": np.asarray(self._comp_edges["type"].to_list()),
                     "nseg_per_branch": self.nseg_per_branch,
-                    "par_inds": self.par_inds,
+                    "par_inds": self._par_inds,
                     "child_inds": self.child_inds,
                     "nbranches": self.total_nbranches,
                     "solver": voltage_solver,

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -132,7 +132,7 @@ class Module(ABC):
             ]
         )
 
-        self.cumsum_nbranches: Optional[np.ndarray] = None
+        self._cumsum_nbranches: Optional[np.ndarray] = None
 
         self.comb_parents: jnp.ndarray = jnp.asarray([-1])
 
@@ -2321,7 +2321,7 @@ class View(Module):
         self.nseg = 1 if len(self.nodes) == 1 else pointer.nseg
         self.total_nbranches = len(self._branches_in_view)
         self.nbranches_per_cell = self._nbranches_per_cell_in_view()
-        self.cumsum_nbranches = jnp.cumsum(np.asarray(self.nbranches_per_cell))
+        self._cumsum_nbranches = jnp.cumsum(np.asarray(self.nbranches_per_cell))
         self.comb_branches_in_each_level = pointer.comb_branches_in_each_level
         self.branch_edges = pointer.branch_edges.loc[self._branch_edges_in_view]
         self.nseg_per_branch = self.base.nseg_per_branch[self._branches_in_view]

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -90,7 +90,7 @@ class Branch(Module):
         self.xyzr = [float("NaN") * np.zeros((2, 4))]
 
     def _init_morph_jaxley_spsolve(self):
-        self.solve_indexer = JaxleySolveIndexer(
+        self._solve_indexer = JaxleySolveIndexer(
             cumsum_nseg=self.cumsum_nseg,
             branchpoint_group_inds=np.asarray([]).astype(int),
             remapped_node_indices=self._internal_node_inds,

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -79,7 +79,7 @@ class Branch(Module):
         )
 
         # For morphology indexing.
-        self.par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
         self._internal_node_inds = jnp.arange(self.nseg)

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -59,7 +59,7 @@ class Branch(Module):
         self.nseg_per_branch = np.asarray([self.nseg])
         self.total_nbranches = 1
         self.nbranches_per_cell = [1]
-        self.cumsum_nbranches = jnp.asarray([0, 1])
+        self._cumsum_nbranches = jnp.asarray([0, 1])
         self.cumsum_nseg = cumsum_leading_zero(self.nseg_per_branch)
 
         # Indexing.

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -79,7 +79,7 @@ class Branch(Module):
         )
 
         # For morphology indexing.
-        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
         self._internal_node_inds = jnp.arange(self.nseg)

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -79,7 +79,7 @@ class Branch(Module):
         )
 
         # For morphology indexing.
-        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self._child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
         self._internal_node_inds = jnp.arange(self.nseg)

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -127,7 +127,7 @@ class Cell(Module):
         )
 
         # For morphology indexing.
-        self.par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
 
@@ -142,13 +142,13 @@ class Cell(Module):
         user will use. Therefore, we always run this function at `.__init__()`.
         """
         children_and_parents = compute_morphology_indices_in_levels(
-            len(self.par_inds),
+            len(self._par_inds),
             self.child_belongs_to_branchpoint,
-            self.par_inds,
+            self._par_inds,
             self.child_inds,
         )
         branchpoint_group_inds = build_branchpoint_group_inds(
-            len(self.par_inds),
+            len(self._par_inds),
             self.child_belongs_to_branchpoint,
             self.cumsum_nseg[-1],
         )
@@ -158,7 +158,7 @@ class Cell(Module):
 
         levels = compute_levels(parents)
         children_in_level = compute_children_in_level(levels, children_inds)
-        parents_in_level = compute_parents_in_level(levels, self.par_inds, parents_inds)
+        parents_in_level = compute_parents_in_level(levels, self._par_inds, parents_inds)
         levels_and_nseg = pd.DataFrame().from_dict(
             {
                 "levels": levels,
@@ -224,8 +224,8 @@ class Cell(Module):
         # Edges from branchpoints to compartments.
         branchpoint_to_parent_edges = pd.DataFrame().from_dict(
             {
-                "source": np.arange(len(self.par_inds)) + self.cumsum_nseg[-1],
-                "sink": self.cumsum_nseg[self.par_inds + 1] - 1,
+                "source": np.arange(len(self._par_inds)) + self.cumsum_nseg[-1],
+                "sink": self.cumsum_nseg[self._par_inds + 1] - 1,
                 "type": 1,
             }
         )

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -93,7 +93,7 @@ class Cell(Module):
         self.nbranches_per_cell = [len(branch_list)]
         self.comb_parents = jnp.asarray(parents)
         self.comb_children = compute_children_indices(self.comb_parents)
-        self.cumsum_nbranches = np.asarray([0, len(branch_list)])
+        self._cumsum_nbranches = np.asarray([0, len(branch_list)])
 
         # Compartment structure. These arguments have to be rebuilt when `.set_ncomp()`
         # is run.

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -127,7 +127,7 @@ class Cell(Module):
         )
 
         # For morphology indexing.
-        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
 
@@ -145,7 +145,7 @@ class Cell(Module):
             len(self._par_inds),
             self.child_belongs_to_branchpoint,
             self._par_inds,
-            self.child_inds,
+            self._child_inds,
         )
         branchpoint_group_inds = build_branchpoint_group_inds(
             len(self._par_inds),
@@ -232,7 +232,7 @@ class Cell(Module):
         branchpoint_to_child_edges = pd.DataFrame().from_dict(
             {
                 "source": self.child_belongs_to_branchpoint + self.cumsum_nseg[-1],
-                "sink": self.cumsum_nseg[self.child_inds],
+                "sink": self.cumsum_nseg[self._child_inds],
                 "type": 2,
             }
         )

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -180,7 +180,7 @@ class Cell(Module):
             padded_cumsum_nseg,
             self.nseg_per_branch,
         )
-        self.solve_indexer = JaxleySolveIndexer(
+        self._solve_indexer = JaxleySolveIndexer(
             cumsum_nseg=padded_cumsum_nseg,
             branchpoint_group_inds=branchpoint_group_inds,
             children_in_level=children_in_level,

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -158,7 +158,9 @@ class Cell(Module):
 
         levels = compute_levels(parents)
         children_in_level = compute_children_in_level(levels, children_inds)
-        parents_in_level = compute_parents_in_level(levels, self._par_inds, parents_inds)
+        parents_in_level = compute_parents_in_level(
+            levels, self._par_inds, parents_inds
+        )
         levels_and_nseg = pd.DataFrame().from_dict(
             {
                 "levels": levels,

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -127,7 +127,7 @@ class Cell(Module):
         )
 
         # For morphology indexing.
-        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self._child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
 
@@ -143,13 +143,13 @@ class Cell(Module):
         """
         children_and_parents = compute_morphology_indices_in_levels(
             len(self._par_inds),
-            self.child_belongs_to_branchpoint,
+            self._child_belongs_to_branchpoint,
             self._par_inds,
             self._child_inds,
         )
         branchpoint_group_inds = build_branchpoint_group_inds(
             len(self._par_inds),
-            self.child_belongs_to_branchpoint,
+            self._child_belongs_to_branchpoint,
             self.cumsum_nseg[-1],
         )
         parents = self.comb_parents
@@ -231,7 +231,7 @@ class Cell(Module):
         )
         branchpoint_to_child_edges = pd.DataFrame().from_dict(
             {
-                "source": self.child_belongs_to_branchpoint + self.cumsum_nseg[-1],
+                "source": self._child_belongs_to_branchpoint + self.cumsum_nseg[-1],
                 "sink": self.cumsum_nseg[self._child_inds],
                 "type": 2,
             }

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -53,7 +53,7 @@ class Compartment(Module):
         )
 
         # For morphology indexing.
-        self.par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
         self._internal_node_inds = jnp.asarray([0])

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -65,7 +65,7 @@ class Compartment(Module):
         self.xyzr = [float("NaN") * np.zeros((2, 4))]
 
     def _init_morph_jaxley_spsolve(self):
-        self.solve_indexer = JaxleySolveIndexer(
+        self._solve_indexer = JaxleySolveIndexer(
             cumsum_nseg=self.cumsum_nseg,
             branchpoint_group_inds=np.asarray([]).astype(int),
             children_in_level=[],

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -53,7 +53,7 @@ class Compartment(Module):
         )
 
         # For morphology indexing.
-        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self._child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
         self._internal_node_inds = jnp.asarray([0])

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -36,7 +36,7 @@ class Compartment(Module):
         self.nseg_per_branch = np.asarray([1])
         self.total_nbranches = 1
         self.nbranches_per_cell = [1]
-        self.cumsum_nbranches = np.asarray([0, 1])
+        self._cumsum_nbranches = np.asarray([0, 1])
         self.cumsum_nseg = cumsum_leading_zero(self.nseg_per_branch)
 
         # Setting up the `nodes` for indexing.

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -53,7 +53,7 @@ class Compartment(Module):
         )
 
         # For morphology indexing.
-        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
         self._internal_node_inds = jnp.asarray([0])

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -94,12 +94,12 @@ class Network(Module):
         )
 
         # For morphology indexing of both `jax.sparse` and the custom `jaxley` solvers.
-        self.par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
 
-        # `nbranchpoints` in each cell == cell.par_inds (because `par_inds` are unique).
-        nbranchpoints = jnp.asarray([len(cell.par_inds) for cell in cells])
+        # `nbranchpoints` in each cell == cell._par_inds (because `par_inds` are unique).
+        nbranchpoints = jnp.asarray([len(cell._par_inds) for cell in cells])
         self.cumsum_nbranchpoints_per_cell = cumsum_leading_zero(nbranchpoints)
 
         # Channels.
@@ -113,7 +113,7 @@ class Network(Module):
 
     def _init_morph_jaxley_spsolve(self):
         branchpoint_group_inds = build_branchpoint_group_inds(
-            len(self.par_inds),
+            len(self._par_inds),
             self.child_belongs_to_branchpoint,
             self.cumsum_nseg[-1],
         )

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -94,7 +94,7 @@ class Network(Module):
         )
 
         # For morphology indexing of both `jax.sparse` and the custom `jaxley` solvers.
-        self._par_inds, self.child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
 

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -120,18 +120,18 @@ class Network(Module):
         children_in_level = merge_cells(
             self.cumsum_nbranches,
             self.cumsum_nbranchpoints_per_cell,
-            [cell.solve_indexer.children_in_level for cell in self._cells_list],
+            [cell._solve_indexer.children_in_level for cell in self._cells_list],
             exclude_first=False,
         )
         parents_in_level = merge_cells(
             self.cumsum_nbranches,
             self.cumsum_nbranchpoints_per_cell,
-            [cell.solve_indexer.parents_in_level for cell in self._cells_list],
+            [cell._solve_indexer.parents_in_level for cell in self._cells_list],
             exclude_first=False,
         )
         padded_cumsum_nseg = cumsum_leading_zero(
             np.concatenate(
-                [np.diff(cell.solve_indexer.cumsum_nseg) for cell in self._cells_list]
+                [np.diff(cell._solve_indexer.cumsum_nseg) for cell in self._cells_list]
             )
         )
 
@@ -143,7 +143,7 @@ class Network(Module):
             padded_cumsum_nseg,
             self.nseg_per_branch,
         )
-        self.solve_indexer = JaxleySolveIndexer(
+        self._solve_indexer = JaxleySolveIndexer(
             cumsum_nseg=padded_cumsum_nseg,
             branchpoint_group_inds=branchpoint_group_inds,
             children_in_level=children_in_level,

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -61,7 +61,7 @@ class Network(Module):
 
         self.nbranches_per_cell = [cell.total_nbranches for cell in cells]
         self.total_nbranches = sum(self.nbranches_per_cell)
-        self.cumsum_nbranches = cumsum_leading_zero(self.nbranches_per_cell)
+        self._cumsum_nbranches = cumsum_leading_zero(self.nbranches_per_cell)
 
         self.nodes = pd.concat([c.nodes for c in cells], ignore_index=True)
         self.nodes["global_comp_index"] = np.arange(self.cumsum_nseg[-1])
@@ -78,7 +78,7 @@ class Network(Module):
 
         parents = [cell.comb_parents for cell in cells]
         self.comb_parents = jnp.concatenate(
-            [p.at[1:].add(self.cumsum_nbranches[i]) for i, p in enumerate(parents)]
+            [p.at[1:].add(self._cumsum_nbranches[i]) for i, p in enumerate(parents)]
         )
 
         # Two columns: `parent_branch_index` and `child_branch_index`. One row per
@@ -100,7 +100,7 @@ class Network(Module):
 
         # `nbranchpoints` in each cell == cell._par_inds (because `par_inds` are unique).
         nbranchpoints = jnp.asarray([len(cell._par_inds) for cell in cells])
-        self.cumsum_nbranchpoints_per_cell = cumsum_leading_zero(nbranchpoints)
+        self._cumsum_nbranchpoints_per_cell = cumsum_leading_zero(nbranchpoints)
 
         # Channels.
         self._gather_channels_from_constituents(cells)
@@ -118,14 +118,14 @@ class Network(Module):
             self.cumsum_nseg[-1],
         )
         children_in_level = merge_cells(
-            self.cumsum_nbranches,
-            self.cumsum_nbranchpoints_per_cell,
+            self._cumsum_nbranches,
+            self._cumsum_nbranchpoints_per_cell,
             [cell._solve_indexer.children_in_level for cell in self._cells_list],
             exclude_first=False,
         )
         parents_in_level = merge_cells(
-            self.cumsum_nbranches,
-            self.cumsum_nbranchpoints_per_cell,
+            self._cumsum_nbranches,
+            self._cumsum_nbranchpoints_per_cell,
             [cell._solve_indexer.parents_in_level for cell in self._cells_list],
             exclude_first=False,
         )
@@ -148,7 +148,7 @@ class Network(Module):
             branchpoint_group_inds=branchpoint_group_inds,
             children_in_level=children_in_level,
             parents_in_level=parents_in_level,
-            root_inds=self.cumsum_nbranches[:-1],
+            root_inds=self._cumsum_nbranches[:-1],
             remapped_node_indices=remapped_node_indices,
         )
 
@@ -188,7 +188,7 @@ class Network(Module):
         start_branchpoints = self.cumsum_nseg[-1]  # Index of the first branchpoint.
         for offset, offset_branchpoints, cell in zip(
             self._cumsum_nseg_per_cell,
-            self.cumsum_nbranchpoints_per_cell,
+            self._cumsum_nbranchpoints_per_cell,
             self._cells_list,
         ):
             offset_within_cell = cell.cumsum_nseg[-1]
@@ -210,7 +210,7 @@ class Network(Module):
         # All compartment-to-branchpoint nodes.
         for offset, offset_branchpoints, cell in zip(
             self._cumsum_nseg_per_cell,
-            self.cumsum_nbranchpoints_per_cell,
+            self._cumsum_nbranchpoints_per_cell,
             self._cells_list,
         ):
             offset_within_cell = cell.cumsum_nseg[-1]

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -94,7 +94,7 @@ class Network(Module):
         )
 
         # For morphology indexing of both `jax.sparse` and the custom `jaxley` solvers.
-        self._par_inds, self._child_inds, self.child_belongs_to_branchpoint = (
+        self._par_inds, self._child_inds, self._child_belongs_to_branchpoint = (
             compute_children_and_parents(self.branch_edges)
         )
 
@@ -114,7 +114,7 @@ class Network(Module):
     def _init_morph_jaxley_spsolve(self):
         branchpoint_group_inds = build_branchpoint_group_inds(
             len(self._par_inds),
-            self.child_belongs_to_branchpoint,
+            self._child_belongs_to_branchpoint,
             self.cumsum_nseg[-1],
         )
         children_in_level = merge_cells(

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -267,7 +267,7 @@ def test_view_attrs(module: jx.Compartment | jx.Branch | jx.Cell | jx.Network):
     exceptions = ["view"]
 
     # TODO: Types are inconsistent between different Modules
-    exceptions += ["cumsum_nbranches"]
+    exceptions += ["_cumsum_nbranches"]
 
     # TODO FROM #447: should be added to View in the future
     exceptions += [
@@ -284,8 +284,8 @@ def test_view_attrs(module: jx.Compartment | jx.Branch | jx.Cell | jx.Network):
     ]  # for base/comp
     exceptions += ["comb_children"]  # for cell
     exceptions += [
-        "cells_list",
-        "cumsum_nbranchpoints_per_cell",
+        "_cells_list",
+        "_cumsum_nbranchpoints_per_cell",
         "_cumsum_nseg_per_cell",
     ]  # for network
 

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -273,7 +273,7 @@ def test_view_attrs(module: jx.Compartment | jx.Branch | jx.Cell | jx.Network):
     exceptions += [
         "_internal_node_inds",
         "_par_inds",
-        "child_inds",
+        "_child_inds",
         "child_belongs_to_branchpoint",
         "solve_indexer",
         "_comp_edges",

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -275,7 +275,7 @@ def test_view_attrs(module: jx.Compartment | jx.Branch | jx.Cell | jx.Network):
         "_par_inds",
         "_child_inds",
         "_child_belongs_to_branchpoint",
-        "solve_indexer",
+        "_solve_indexer",
         "_comp_edges",
         "_n_nodes",
         "_data_inds",

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -272,7 +272,7 @@ def test_view_attrs(module: jx.Compartment | jx.Branch | jx.Cell | jx.Network):
     # TODO FROM #447: should be added to View in the future
     exceptions += [
         "_internal_node_inds",
-        "par_inds",
+        "_par_inds",
         "child_inds",
         "child_belongs_to_branchpoint",
         "solve_indexer",

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -274,7 +274,7 @@ def test_view_attrs(module: jx.Compartment | jx.Branch | jx.Cell | jx.Network):
         "_internal_node_inds",
         "_par_inds",
         "_child_inds",
-        "child_belongs_to_branchpoint",
+        "_child_belongs_to_branchpoint",
         "solve_indexer",
         "_comp_edges",
         "_n_nodes",


### PR DESCRIPTION
Closes #448

@michaeldeistler @jnsbck is the list of methods/attributes to make private actually agreed upon? Here's what was stated int he issue:

```
"par_inds",
"child_inds",
"child_belongs_to_branchpoint",
"solve_indexer",
"cells_list",
"cumsum_nbranchpoints_per_cell",
"cumsum_nbranches"
```
I've started with `par_inds` to get a feel for the code base, but I'll wait for you input before continuing