### PR TITLE
Enable param sharing with differently sized groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ net.arrange_in_layers([3,3])
 net.vis()
 ```
 
+- Allow parameter sharing for groups of different sizes, i.e. due to inhomogenous numbers of compartments or for synapses with the same (pre-)synaptic parameters but different numbers of post-synaptic partners. (#514, @jnsbck)
+
 # 0.5.0
 
 ### API changes

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1081,7 +1081,8 @@ class Module(ABC):
 
         # check if all shapes in comp_inds are the same. If not the case this means
         # the groups in controlled_by_param have different sizes, i.e. due to different
-        # number of comps for two different branches.
+        # number of comps for two different branches. In this case we pad the smaller
+        # groups with -1 to make them the same size.
         lens = np.array([inds.shape[0] for inds in comp_inds])
         max_len = np.max(lens)
         pad = lambda x: np.pad(x, (0, max_len - x.shape[0]), constant_values=-1)
@@ -1091,7 +1092,7 @@ class Module(ABC):
         indices_per_param = jnp.stack(comp_inds)
 
         # Sorted inds are only used to infer the correct starting values.
-        data.loc[-1, key] = np.nan  # assign dummy index to NaN
+        data.loc[-1, key] = np.nan  # assign dummy param (ignored by nanmean later)
         param_vals = jnp.asarray([data.loc[inds, key].to_numpy() for inds in comp_inds])
 
         # Set the value which the trainable parameter should take.

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1087,7 +1087,9 @@ class Module(ABC):
         max_len = np.max(lens)
         pad = lambda x: np.pad(x, (0, max_len - x.shape[0]), constant_values=-1)
         if not np.all(lens == max_len):
-            comp_inds = [pad(inds) for inds in comp_inds if inds.shape[0] < max_len]
+            comp_inds = [
+                pad(inds) if inds.shape[0] < max_len else inds for inds in comp_inds
+            ]
 
         indices_per_param = jnp.stack(comp_inds)
 

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1058,9 +1058,6 @@ class Module(ABC):
         ncomps_per_branch = (
             self.base.nodes["global_branch_index"].value_counts().to_numpy()
         )
-        assert np.all(
-            ncomps_per_branch == ncomps_per_branch[0]
-        ), "Parameter sharing is not allowed for modules containing branches with different numbers of compartments."
 
         data = self.nodes if key in self.nodes.columns else None
         data = self.edges if key in self.edges.columns else data

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1088,10 +1088,14 @@ class Module(ABC):
                 pad(inds) if inds.shape[0] < max_len else inds for inds in comp_inds
             ]
 
+        # Sorted inds are only used to infer the correct starting values.
         indices_per_param = jnp.stack(comp_inds)
 
-        # Sorted inds are only used to infer the correct starting values.
-        data.loc[-1, key] = np.nan  # assign dummy param (ignored by nanmean later)
+        # Assign dummy param (ignored by nanmean later). This adds a new row to the
+        # `data` (which is, e.g., self.nodes). That new row has index `-1`, which does
+        # not clash with any other node index (they are in
+        # `[0, ..., num_total_comps-1]`).
+        data.loc[-1, key] = np.nan
         param_vals = jnp.asarray([data.loc[inds, key].to_numpy() for inds in comp_inds])
 
         # Set the value which the trainable parameter should take.

--- a/tests/test_make_trainable.py
+++ b/tests/test_make_trainable.py
@@ -531,3 +531,15 @@ def test_write_trainables(SimpleNet):
     # Test whether synapse view raises an error.
     with pytest.raises(AssertionError):
         net.select(edges=[0, 2, 3]).write_trainables(params)
+
+
+def test_param_sharing_w_different_group_sizes():
+    branch = jx.Branch(nseg=6)
+    branch.nodes["controlled_by_param"] = np.array([0, 0, 0, 1, 1, 2])
+    branch.make_trainable("radius")
+    assert branch.num_trainable_params == 3
+
+    params = branch.get_parameters()
+    branch.to_jax()
+    pstate = params_to_pstate(params, branch.indices_set_by_trainables)
+    branch.get_all_parameters(pstate, voltage_solver="jaxley.thomas")


### PR DESCRIPTION
This PR attempts to enable param sharing for controll groups with different numbers of members. This can be important for sharing params between branches with different numbers of segments or edges with different numbers of pre synaptic cells (see #501).

This also fixes #501.

todos:
- [x] add tests
- [x] rm asserts that prev. prevented the user from doing this.