### PR TITLE
[MRG] Add ability to record synaptic currents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.6.0
+
+### New Features
+
+- Add ability to record synaptic currents (#523, @ntolley). Recordings can be turned on with
+```python
+net.record("i_IonotropicSynapse")
+```
+
+
 # 0.5.0
 
 ### API changes

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1210,7 +1210,10 @@ class Module(ABC):
         channel_states = [name for c in self.channels for name in c.channel_states]
         synapse_states = [name for s in self.synapses for name in s.synapse_states]
         membrane_states = ["v", "i"] + self.membrane_current_names
-        return channel_states + membrane_states, synapse_states + self.synapse_current_names
+        return (
+            channel_states + membrane_states,
+            synapse_states + self.synapse_current_names,
+        )
 
     def get_parameters(self) -> List[Dict[str, jnp.ndarray]]:
         """Get all trainable parameters.

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -2495,7 +2495,7 @@ class View(Module):
             ].unique()
             pre = base_edges["pre_global_comp_index"].isin(incl_comps).to_numpy()
             post = base_edges["post_global_comp_index"].isin(incl_comps).to_numpy()
-            possible_edges_in_view = base_edges.index.to_numpy()[(pre & post).flatten()]
+            possible_edges_in_view = base_edges.index.to_numpy()[(pre | post).flatten()]
             self._edges_in_view = np.intersect1d(
                 possible_edges_in_view, self._edges_in_view
             )

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -148,6 +148,7 @@ class Module(ABC):
         self.synapse_param_names = []
         self.synapse_state_names = []
         self.synapse_names = []
+        self.synapse_current_names: List[str] = []
 
         # List of types of all `jx.Channel`s.
         self.channels: List[Channel] = []
@@ -1209,7 +1210,7 @@ class Module(ABC):
         channel_states = [name for c in self.channels for name in c.channel_states]
         synapse_states = [name for s in self.synapses for name in s.synapse_states]
         membrane_states = ["v", "i"] + self.membrane_current_names
-        return channel_states + membrane_states, synapse_states
+        return channel_states + membrane_states, synapse_states + self.synapse_current_names
 
     def get_parameters(self) -> List[Dict[str, jnp.ndarray]]:
         """Get all trainable parameters.
@@ -2445,6 +2446,7 @@ class View(Module):
 
         self.channels = self._channels_in_view(pointer)
         self.membrane_current_names = [c._name for c in self.channels]
+        self.synapse_current_names = pointer.synapse_current_names
         self._set_trainables_in_view()  # run after synapses and channels
         self.num_trainable_params = (
             np.sum([len(inds) for inds in self.indices_set_by_trainables])

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -2495,8 +2495,9 @@ class View(Module):
             incl_comps = pointer.nodes.loc[
                 self._nodes_in_view, "global_comp_index"
             ].unique()
+            pre = base_edges["pre_global_comp_index"].isin(incl_comps).to_numpy()
             post = base_edges["post_global_comp_index"].isin(incl_comps).to_numpy()
-            possible_edges_in_view = base_edges.index.to_numpy()[(post).flatten()]
+            possible_edges_in_view = base_edges.index.to_numpy()[(pre & post).flatten()]
             self._edges_in_view = np.intersect1d(
                 possible_edges_in_view, self._edges_in_view
             )

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -2448,7 +2448,7 @@ class View(Module):
         )
 
         self.channels = self._channels_in_view(pointer)
-        self.membrane_current_names = [c._name for c in self.channels]
+        self.membrane_current_names = [c.current_name for c in self.channels]
         self.synapse_current_names = pointer.synapse_current_names
         self._set_trainables_in_view()  # run after synapses and channels
         self.num_trainable_params = (
@@ -2640,7 +2640,7 @@ class View(Module):
         viewed_synapses = []
         viewed_params = []
         viewed_states = []
-        if not pointer.synapses is None:
+        if pointer.synapses is not None:
             for syn in pointer.synapses:
                 if syn is not None:  # needed for recurive viewing
                     in_view = syn._name in self.synapse_names

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1208,7 +1208,9 @@ class Module(ABC):
 
         Returns states seperated by comps and edges."""
         channel_states = [name for c in self.channels for name in c.channel_states]
-        synapse_states = [name for s in self.synapses for name in s.synapse_states]
+        synapse_states = [
+            name for s in self.synapses if s is not None for name in s.synapse_states
+        ]
         membrane_states = ["v", "i"] + self.membrane_current_names
         return (
             channel_states + membrane_states,
@@ -2493,9 +2495,8 @@ class View(Module):
             incl_comps = pointer.nodes.loc[
                 self._nodes_in_view, "global_comp_index"
             ].unique()
-            pre = base_edges["pre_global_comp_index"].isin(incl_comps).to_numpy()
             post = base_edges["post_global_comp_index"].isin(incl_comps).to_numpy()
-            possible_edges_in_view = base_edges.index.to_numpy()[(pre | post).flatten()]
+            possible_edges_in_view = base_edges.index.to_numpy()[(post).flatten()]
             self._edges_in_view = np.intersect1d(
                 possible_edges_in_view, self._edges_in_view
             )

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -379,7 +379,7 @@ class Network(Module):
             # `post_syn_currents` is a `jnp.ndarray` of as many elements as there are
             # compartments in the network.
             # `[0]` because we only use the non-perturbed voltage.
-            states[f"{synapse_type._name}_current"] = synapse_currents[0]
+            states[f"i_{synapse_type._name}"] = synapse_currents[0]
 
         return states, (syn_voltage_terms, syn_constant_terms)
 
@@ -565,7 +565,7 @@ class Network(Module):
     def _append_multiple_synapses(self, pre_nodes, post_nodes, synapse_type):
         # Add synapse types to the module and infer their unique identifier.
         synapse_name = synapse_type._name
-        synapse_current_name = f"{synapse_name}_current"
+        synapse_current_name = f"i_{synapse_name}"
         type_ind, is_new = self._infer_synapse_type_ind(synapse_name)
         if is_new:  # synapse is not known
             self._update_synapse_state_names(synapse_type)

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -565,9 +565,11 @@ class Network(Module):
     def _append_multiple_synapses(self, pre_nodes, post_nodes, synapse_type):
         # Add synapse types to the module and infer their unique identifier.
         synapse_name = synapse_type._name
+        synapse_current_name = f"{synapse_name}_current"
         type_ind, is_new = self._infer_synapse_type_ind(synapse_name)
         if is_new:  # synapse is not known
             self._update_synapse_state_names(synapse_type)
+            self.base.synapse_current_names.append(synapse_current_name)
 
         index = len(self.base.edges)
         indices = [idx for idx in range(index, index + len(pre_nodes))]

--- a/tests/test_record_and_stimulate.py
+++ b/tests/test_record_and_stimulate.py
@@ -81,7 +81,8 @@ def test_record_synaptic_and_membrane_states(SimpleNet):
     net.cell(1).branch(0).loc(0.0).record("v")
     net.TestSynapse.edge(0).record("TestSynapse_c")
     net.cell(1).branch(0).loc(0.0).record("HH_m")
-    net.IonotropicSynapse.edge(1).record("IonotropicSynapse_current")
+    net.cell(1).branch(0).loc(0.0).record("i_HH")
+    net.IonotropicSynapse.edge(1).record("i_IonotropicSynapse")
 
     recs = jx.integrate(net)
 

--- a/tests/test_record_and_stimulate.py
+++ b/tests/test_record_and_stimulate.py
@@ -75,6 +75,7 @@ def test_record_synaptic_and_membrane_states(SimpleNet):
     )
     net.cell(0).branch(0).loc(0.0).stimulate(current)
 
+    # Invoke recording of voltage and synaptic states.
     net.cell(2).branch(0).loc(0.0).record("v")
     net.IonotropicSynapse.edge(1).record("IonotropicSynapse_s")
     net.cell(2).branch(0).loc(0.0).record("HH_m")
@@ -83,6 +84,17 @@ def test_record_synaptic_and_membrane_states(SimpleNet):
     net.cell(1).branch(0).loc(0.0).record("HH_m")
     net.cell(1).branch(0).loc(0.0).record("i_HH")
     net.IonotropicSynapse.edge(1).record("i_IonotropicSynapse")
+
+    # Advanced synapse indexing for recording.
+    net.copy_node_property_to_edges("global_cell_index")
+    # Record currents from specific post synaptic cells.
+    df = net.edges
+    df = df.query("pre_global_cell_index in [0, 1]")
+    net.select(edges=df.index).record("i_IonotropicSynapse")
+    # Record currents from specific synapse types
+    df = net.edges
+    df = df.query("type == 'TestSynapse'")
+    net.select(edges=df.index).record("i_TestSynapse")
 
     recs = jx.integrate(net)
 

--- a/tests/test_record_and_stimulate.py
+++ b/tests/test_record_and_stimulate.py
@@ -81,10 +81,11 @@ def test_record_synaptic_and_membrane_states(SimpleNet):
     net.cell(1).branch(0).loc(0.0).record("v")
     net.TestSynapse.edge(0).record("TestSynapse_c")
     net.cell(1).branch(0).loc(0.0).record("HH_m")
+    net.IonotropicSynapse.edge(1).record("IonotropicSynapse_current")
 
     recs = jx.integrate(net)
 
-    # Loop over first two recorings and then the second two recordings.
+    # Loop over first two recordings and then the second two recordings.
     for index in [0, 3]:
         # Local maxima of voltage trace.
         y = recs[index]


### PR DESCRIPTION
Closes #363 and #533

As discussed with @jnsbck in #515, this PR adds `synapse_current_names` as an attribute to the base module, and then appends this to the synapse states in `_get_state_names()`. The end goal is for currents to be recordable via:

```py
net.record('IonotropicSynapse_current')
```

Some lingering thoughts:
1) Is it worth changing "current" to "i" for consistency with the channel naming conventions?
2) It took me awhile to figure out that I needed to modify the `View` class. Will it be necessary to add a `self._synapses_in_view()` property for this to work properly?
3) Add some tests that check basic assumptions of the current recording?