### PR TITLE
Confidence bounds for regression tests

### DIFF
--- a/.github/workflows/update_regression_baseline.yml
+++ b/.github/workflows/update_regression_baseline.yml
@@ -12,8 +12,8 @@ jobs:
   update_regression_tests:
     name: update_regression_tests
     runs-on: ubuntu-20.04
-    # Trigger from a comment that contains '/update_regression_baselines'
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/update_regression_baselines')
+    # Trigger from a comment that contains '/update_regression_baseline'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/update_regression_baseline')
     # workflow needs permissions to write to the PR
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ coverage.xml
 .pytest_cache/
 tests/regression_test_results.json
 tests/regression_test_baselines.json
+tests/regression_test_report.txt
 
 # Translations
 *.mo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,7 +209,9 @@ def swc2jaxley():
 @pytest.fixture(scope="session", autouse=True)
 def print_session_report(request, pytestconfig):
     """Cleanup a testing directory once we are finished."""
-    NEW_BASELINE = os.environ["NEW_BASELINE"] if "NEW_BASELINE" in os.environ else 0
+    NEW_BASELINE = (
+        int(os.environ["NEW_BASELINE"]) if "NEW_BASELINE" in os.environ else 0
+    )
 
     dirname = os.path.dirname(__file__)
     baseline_fname = os.path.join(dirname, "regression_test_baselines.json")
@@ -220,11 +222,10 @@ def print_session_report(request, pytestconfig):
     ]
 
     def update_baseline():
-        if NEW_BASELINE:
-            results = load_json(results_fname)
-            with open(baseline_fname, "w") as f:
-                json.dump(results, f, indent=2)
-            os.remove(results_fname)
+        results = load_json(results_fname)
+        with open(baseline_fname, "w") as f:
+            json.dump(results, f, indent=2)
+        os.remove(results_fname)
 
     def print_regression_report():
         baselines = load_json(baseline_fname)
@@ -243,5 +244,6 @@ def print_session_report(request, pytestconfig):
             print(report)
 
     if len(collected_regression_tests) > 0:
-        request.addfinalizer(update_baseline)
+        if NEW_BASELINE:
+            request.addfinalizer(update_baseline)
         request.addfinalizer(print_regression_report)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -160,7 +160,7 @@ class compare_to_baseline:
                 func_baselines = self.baselines[key]["runtimes"]
                 for key, baseline in func_baselines.items():
                     assert (
-                        runtimes[key] < baseline
+                        runtimes[key] <= baseline
                     ), f"{key} is significantly slower than the baseline at {runtimes[key]:.3f}s vs. {baseline:.3f}s."
 
         return test_wrapper

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -76,9 +76,9 @@ def generate_regression_report(base_results, new_results):
             status = ""
             if base_time is None:
                 status = "🆕"
-            elif new_time < base_time:
+            elif new_time <= base_time:
                 status = "🟢" if diff is not None and diff < -0.05 else "🟠"
-            elif new_time >= base_time:
+            elif new_time > base_time:
                 status = "🔴"
             else:
                 status = "❌"  # This should never happen.
@@ -104,8 +104,8 @@ def generate_unique_key(d):
 
 def compute_conf_bounds(X):
     df = len(X) - 1  # degrees of freedom = n-1
-    t_value = t_dist.ppf(CONFIDENCE, df)
-    return np.mean(X) + t_value * np.std(X, ddof=1)  # sample std
+    critical_value = t_dist.ppf(CONFIDENCE, df)
+    return np.mean(X) + critical_value * np.std(X, ddof=1)  # sample std
 
 
 def load_json(fpath):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.regression  # mark all tests as regression tests in thi
 # takes into account the input_kwargs of the test, the name of the test and the runtimes
 # of each part.
 
-NEW_BASELINE = os.environ["NEW_BASELINE"] if "NEW_BASELINE" in os.environ else 0
+NEW_BASELINE = int(os.environ["NEW_BASELINE"]) if "NEW_BASELINE" in os.environ else 0
 CONFIDENCE = 0.95
 
 dirname = os.path.dirname(__file__)
@@ -71,20 +71,18 @@ def generate_regression_report(base_results, new_results):
         report.append(func_signature)
         for key, new_time in new_runtimes.items():
             base_time = base_runtimes.get(key)
+            diff = None if base_time is None else ((new_time - base_time) / base_time)
 
             status = ""
             if base_time is None:
                 status = "🆕"
+            elif new_time < base_time:
+                status = "🟢" if diff is not None and diff < -0.05 else "🟠"
             elif new_time >= base_time:
                 status = "🔴"
-            elif new_time < base_time * (1 - 0.05):
-                status = "🟠"  # time is very close to the confidence bound
-            elif new_time < base_time:
-                status = "🟢"
             else:
                 status = "❌"  # This should never happen.
 
-            diff = None if base_time is None else ((new_time - base_time) / base_time)
             time_str = (
                 f"({new_time:.3f}s)"
                 if diff is None


### PR DESCRIPTION
Regression is now evaluated with a single sample t-test, i.e. the baseline times = conf bounds. This is much nicer imo and giving a confidence region for tests to pass should also make it more robust to potential runtime fluctuations on the github runners.

Also made a few smaller follow up fixes for #475.