### PR TITLE
Assigning np_dtype based on what the dtype numpy picks by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ net.vis()
 
 - changelog added to CI (#537, #558,  @jnsbck)
 
+### Bug fixes
+- Fixed inconsistency with *type* assertions arising due to `numpy` functions returning different `dtypes` on platforms like Windows (#567, @Kartik-Sama)
+
 # 0.5.0
 
 ### API changes

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -392,8 +392,7 @@ class Module(ABC):
             array of indices of shape (N,)"""
         if is_str_all(idx):  # also asserts that the only allowed str == "all"
             return idx
-
-        np_dtype = np.int64 if dtype is int else np.float64
+        np_dtype = np.dtype(int).type if dtype is int else np.dtype(float).type
         idx = np.array([], dtype=dtype) if idx is None else idx
         idx = np.array([idx]) if isinstance(idx, (dtype, np_dtype)) else idx
         idx = np.array(idx) if isinstance(idx, (list, range, pd.Index)) else idx


### PR DESCRIPTION
By using the _dtype_ assigned by _numpy_ for the types **int** and **float** , one doesn't need to have any further checks based on the platform they are using.