### PR TITLE
Update pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.6.0
 
+### Pin of JAX version
+
+Installing `Jaxley` will no longer install the newest version of `JAX`. We realized that, on CPU, with version `jax==0.4.32` or newer, simulation time in `Jaxley` is 10x slower and gradient time is 5x slower as compared to older versions of JAX. Newer versions of `JAX` can be made equally fast as older versions by setting `os.environ['XLA_FLAGS'] = '--xla_cpu_use_thunk_runtime=false'` at the beginning of your jupyter notebook (#570, @michaeldeistler).
+
 ### New Features
 
 - Add ability to record synaptic currents (#523, @ntolley). Recordings can be turned on with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,11 @@ requires-python = ">=3.10"
 readme = "README.md"
 keywords = ["neuroscience", "biophysics", "simulator", "jax"]
 dependencies = [
-    "jax",
+    # See #571 for the pin on the JAX version. Jaxley runs with newer versions of JAX
+    # but is much slower on CPU. Newer versions can be made equally fast by setting
+    # `os.environ['XLA_FLAGS'] = '--xla_cpu_use_thunk_runtime=false'` at the beginning
+    # of a jupyter notebook.
+    "jax <= 0.4.31",
     "matplotlib",
     "numpy",
     "pandas>=2.2.0",


### PR DESCRIPTION
This PR pins the jaxley versions to be older than `0.4.32`.

I realized that, with version jax==0.4.32 or newer, simulation time is 10x slower and gradient time is 5x slower as compared to older versions of JAX 🤯 

From the CHANGELOG of JAX:
```
This release of jaxlib switched to a new version of the CPU backend, which should compile faster
and leverage parallelism better. If you experience any problems due to this change, you can
temporarily enable the old CPU backend by setting the environment variable 
XLA_FLAGS=--xla_cpu_use_thunk_runtime=false. If you need to  do this, please file a JAX
bug with instructions to reproduce.
```
Indeed, os.environ['XLA_FLAGS'] = '--xla_cpu_use_thunk_runtime=false' at the beginning of the notebook fixes it also for newer versions of JAX.

See also [this issue that I created on the JAX repo](https://github.com/jax-ml/jax/issues/26145).