### PR TITLE
Prepare release; allow easy access of version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,14 +36,19 @@ net.vis()
   - See [the improved SWC reader tutorial](https://jaxley.readthedocs.io/en/latest/tutorials/08_importing_morphologies.html) for more details.
 
 ### Code Health
+
 - changelog added to CI (#537, #558,  @jnsbck)
 
 - Add regression tests and supporting workflows for maintaining baselines (#475, #546, @jnsbck).
   - Regression tests can be triggered by commenting "/test_regression" on a PR.
   - Regression tests can be done locally by running `NEW_BASELINE=1 pytest -m regression` i.e. on `main` and then `pytest -m regression` on `feature`, which will produce a test report (printed to the console and saved to .txt).
 
+- Allow inspecting the version via `import jaxley as jx; print(jx.__version__)` (#577, @michaeldeistler).
+
 ### Bug fixes
+
 - Fixed inconsistency with *type* assertions arising due to `numpy` functions returning different `dtypes` on platforms like Windows (#567, @Kartik-Sama)
+
 
 # 0.5.0
 

--- a/jaxley/__init__.py
+++ b/jaxley/__init__.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+from jaxley.__version__ import __version__
 from jaxley.connect import (
     connect,
     connectivity_matrix_connect,

--- a/jaxley/__version__.py
+++ b/jaxley/__version__.py
@@ -1,6 +1,6 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-VERSION = (0, 5, 0)
+VERSION = (0, 6, 0)
 
 __version__ = ".".join(map(str, VERSION))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Jaxley"
-version = "0.5.0"
+version = "0.6.0"
 description = "Differentiable neuron simulations."
 authors = [
     { name = "jaxleyverse", email = "jaxleyverse@gmail.com"},


### PR DESCRIPTION
I realized that:
```python
import jaxley as jx
print(jx.__version__)
```
had not been possible due to the missing import.