### PR TITLE
deprecate nseg and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.6.1
 
-- Fixup for failing readthedocs build of v0.6.0 (#579, @michaeldeistler).
+- Fixup for failing readthedocs build of v0.6.0 (#579, @michaeldeistler)
+- Deprecate `nseg` in favor of `ncomp`.
 
 
 # 0.6.0

--- a/jaxley/__version__.py
+++ b/jaxley/__version__.py
@@ -1,6 +1,6 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-VERSION = (0, 6, 0)
+VERSION = (0, 6, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/jaxley/io/graph.py
+++ b/jaxley/io/graph.py
@@ -492,7 +492,7 @@ def make_jaxley_compatible(
 
     Args:
         graph: A networkx graph of a traced morphology.
-        nseg: The number of segments per compartment.
+        ncomp: The number of segments per compartment.
         max_branch_len: Maximal length of one branch. If a branch exceeds this length,
             it is split into equal parts.
         min_radius: If the radius of a reconstruction is below this value it is clipped.
@@ -595,8 +595,8 @@ def build_module_scaffold(
     build_cache["compartment"] = [comp]
 
     if return_type in return_types[1:]:
-        nsegs = idxs["branch_index"].value_counts().iloc[0]
-        branch = Branch([comp for _ in range(nsegs)])
+        ncomps = idxs["branch_index"].value_counts().iloc[0]
+        branch = Branch([comp for _ in range(ncomps)])
         build_cache["branch"] = [branch]
 
     if return_type in return_types[2:]:
@@ -683,7 +683,7 @@ def from_graph(
 
     Args:
         graph: A networkx graph representing a module.
-        nseg: The default number of segments per compartment.
+        ncomp: The default number of segments per compartment.
             Will only be selected if the graph has not been compartmentalized yet.
         max_branch_len: Maximal length of one branch. If a branch exceeds this length,
             it is split into equal parts such that each subbranch is below

--- a/jaxley/io/swc.py
+++ b/jaxley/io/swc.py
@@ -339,11 +339,9 @@ def swc_to_jaxley(
     return parents, pathlengths, radius_fns, types, all_coords_of_branches
 
 
-@deprecated_kwargs("0.6.0", ["nseg"])
 def read_swc_custom(
     fname: str,
     ncomp: Optional[int] = None,
-    nseg: Optional[int] = None,
     max_branch_len: Optional[float] = None,
     min_radius: Optional[float] = None,
     assign_groups: bool = True,
@@ -358,7 +356,6 @@ def read_swc_custom(
     Args:
         fname: Path to the swc file.
         ncomp: The number of compartments per branch.
-        nseg: Deprecated. Use `ncomp` instead.
         max_branch_len: If a branch is longer than this value it is split into two
             branches.
         min_radius: If the radius of a reconstruction is below this value it is clipped.
@@ -370,14 +367,6 @@ def read_swc_custom(
     Returns:
         A `Cell` object.
     """
-    # Deak with deprecation of `nseg`.
-    assert ncomp is not None or nseg is not None, "You must pass `ncomp`."
-    assert not (
-        ncomp is not None and nseg is not None
-    ), "Cannot set `ncomp` and `nseg`. Only use `ncomp`."
-    if ncomp is None and nseg is not None:
-        ncomp = nseg
-
     parents, pathlengths, radius_fns, types, coords_of_branches = swc_to_jaxley(
         fname, max_branch_len=max_branch_len, sort=True, num_lines=None
     )
@@ -426,11 +415,9 @@ def read_swc_custom(
     return cell
 
 
-@deprecated_kwargs("0.6.0", ["nseg"])
 def read_swc(
     fname: str,
     ncomp: Optional[int] = None,
-    nseg: Optional[int] = None,
     max_branch_len: Optional[float] = None,
     min_radius: Optional[float] = None,
     assign_groups: bool = True,
@@ -446,7 +433,6 @@ def read_swc(
     Args:
         fname: Path to the swc file.
         ncomp: The number of compartments per branch.
-        nseg: Deprecated. Use `ncomp` instead.
         max_branch_len: If a branch is longer than this value it is split into two
             branches.
         min_radius: If the radius of a reconstruction is below this value it is clipped.
@@ -464,7 +450,6 @@ def read_swc(
         return read_swc_custom(
             fname,
             ncomp=ncomp,
-            nseg=nseg,
             max_branch_len=max_branch_len,
             min_radius=min_radius,
             assign_groups=assign_groups,

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -27,12 +27,10 @@ class Branch(Module):
     branch_params: Dict = {}
     branch_states: Dict = {}
 
-    @deprecated_kwargs("0.6.0", ["nseg"])
     def __init__(
         self,
         compartments: Optional[Union[Compartment, List[Compartment]]] = None,
         ncomp: Optional[int] = None,
-        nseg: Optional[int] = None,
     ):
         """
         Args:
@@ -42,13 +40,6 @@ class Branch(Module):
                 a single compartment, than the compartment is repeated `ncomp` times to
                 create the branch.
         """
-        # Warnings and errors that deal with the change from `nseg` to `ncomp` change
-        # in Jaxley v0.5.0.
-        if ncomp is not None and nseg is not None:
-            raise ValueError("You passed `ncomp` and `nseg`. Please pass only `ncomp`.")
-        if ncomp is None and nseg is not None:
-            ncomp = nseg
-
         super().__init__()
         assert (
             isinstance(compartments, (Compartment, List)) or compartments is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Jaxley"
-version = "0.6.0"
+version = "0.6.1"
 description = "Differentiable neuron simulations."
 authors = [
     { name = "jaxleyverse", email = "jaxleyverse@gmail.com"},

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 
-def get_segment_xyzrL(section, comp_idx=None, loc=None, nseg=8):
+def get_segment_xyzrL(section, comp_idx=None, loc=None, ncomp=8):
     assert (
         comp_idx is not None or loc is not None
     ), "Either comp_idx or loc must be provided."
@@ -13,7 +13,7 @@ def get_segment_xyzrL(section, comp_idx=None, loc=None, nseg=8):
         comp_idx is not None and loc is not None
     ), "Only one of comp_idx or loc can be provided."
 
-    comp_len = 1 / nseg
+    comp_len = 1 / ncomp
     loc = comp_len / 2 + comp_idx * comp_len if loc is None else loc
 
     n3d = section.n3d()
@@ -42,12 +42,12 @@ def get_segment_xyzrL(section, comp_idx=None, loc=None, nseg=8):
         y = y3d[i - 1] + t * (y3d[i] - y3d[i - 1])
         z = z3d[i - 1] + t * (z3d[i] - z3d[i - 1])
         r = r3d[i - 1] + t * (r3d[i] - r3d[i - 1])
-        return x, y, z, r, L[-1] / nseg
+        return x, y, z, r, L[-1] / ncomp
 
 
-def jaxley2neuron_by_coords(jx_cell, neuron_secs, comp_idx=None, loc=None, nseg=8):
+def jaxley2neuron_by_coords(jx_cell, neuron_secs, comp_idx=None, loc=None, ncomp=8):
     neuron_coords = {
-        i: np.vstack(get_segment_xyzrL(sec, comp_idx=comp_idx, loc=loc, nseg=nseg))[
+        i: np.vstack(get_segment_xyzrL(sec, comp_idx=comp_idx, loc=loc, ncomp=ncomp))[
             :3
         ].T
         for i, sec in enumerate(neuron_secs)
@@ -81,7 +81,7 @@ def jaxley2neuron_by_group(
     neuron_secs,
     comp_idx=None,
     loc=None,
-    nseg=8,
+    ncomp=8,
     num_apical=20,
     num_tuft=20,
     num_basal=10,
@@ -99,7 +99,7 @@ def jaxley2neuron_by_group(
     )
 
     jaxley2neuron = jaxley2neuron_by_coords(
-        jx_cell, neuron_secs, comp_idx=comp_idx, loc=loc, nseg=nseg
+        jx_cell, neuron_secs, comp_idx=comp_idx, loc=loc, ncomp=ncomp
     )
 
     neuron_trunk_inds = [jaxley2neuron[i] for i in trunk_inds]
@@ -115,22 +115,22 @@ def jaxley2neuron_by_group(
     return neuron_inds, jaxley_inds
 
 
-def match_stim_loc(jx_cell, neuron_sec, comp_idx=None, loc=None, nseg=8):
-    stim_coords = get_segment_xyzrL(neuron_sec, comp_idx=comp_idx, loc=loc, nseg=nseg)[
-        :3
-    ]
+def match_stim_loc(jx_cell, neuron_sec, comp_idx=None, loc=None, ncomp=8):
+    stim_coords = get_segment_xyzrL(
+        neuron_sec, comp_idx=comp_idx, loc=loc, ncomp=ncomp
+    )[:3]
     stim_idx = (
         ((jx_cell.nodes[["x", "y", "z"]] - stim_coords) ** 2).sum(axis=1).argmin()
     )
     return stim_idx
 
 
-def import_neuron_morph(fname, nseg=8):
+def import_neuron_morph(fname, ncomp=8):
     from neuron import h
 
     _ = h.load_file("stdlib.hoc")
     _ = h.load_file("import3d.hoc")
-    nseg = 8
+    ncomp = 8
 
     ##################### NEURON ##################
     for sec in h.allsec():
@@ -142,7 +142,7 @@ def import_neuron_morph(fname, nseg=8):
     i3d.instantiate(None)
 
     for sec in h.allsec():
-        sec.nseg = nseg
+        sec.nseg = ncomp
     return h, cell
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -184,7 +184,7 @@ def test_from_graph_vs_NEURON(file):
         graph, ncomp=ncomp, max_branch_len=2000, ignore_swc_trace_errors=False
     )
     cell.compute_compartment_centers()
-    h, neuron_cell = import_neuron_morph(fname, nseg=ncomp)
+    h, neuron_cell = import_neuron_morph(fname, ncomp=ncomp)
 
     # remove root branch
     jaxley_comps = cell.nodes[
@@ -274,7 +274,7 @@ def test_swc2graph_voltages(file):
     dt = 0.025
 
     ##################### NEURON ##################
-    h, neuron_cell = import_neuron_morph(fname, nseg=ncomp)
+    h, neuron_cell = import_neuron_morph(fname, ncomp=ncomp)
 
     ####################### jaxley ##################
     graph = swc_to_graph(fname)

--- a/tests/test_make_trainable.py
+++ b/tests/test_make_trainable.py
@@ -535,7 +535,7 @@ def test_write_trainables(SimpleNet):
 
 def test_param_sharing_w_different_group_sizes():
     # test if make_trainable corresponds to set
-    branch1 = jx.Branch(nseg=6)
+    branch1 = jx.Branch(ncomp=6)
     branch1.nodes["controlled_by_param"] = np.array([0, 0, 0, 1, 1, 2])
     branch1.make_trainable("radius")
     assert branch1.num_trainable_params == 3
@@ -548,7 +548,7 @@ def test_param_sharing_w_different_group_sizes():
     params1 = branch1.get_all_parameters(pstate, voltage_solver="jaxley.thomas")
 
     # set
-    branch2 = jx.Branch(nseg=6)
+    branch2 = jx.Branch(ncomp=6)
     branch2.set("radius", np.array([2, 2, 2, 3, 3, 4]))
     params = branch2.get_parameters()
     branch2.to_jax()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import List
 
 import numpy as np
-import pytest
 
 
 def test_rm_all_deprecated_functions():
@@ -15,10 +14,12 @@ def test_rm_all_deprecated_functions():
 
     package_version = np.array([int(s) for s in package_version.split(".")])
 
-    decorator_pattern = r"@deprecated(?:_signature)?"
+    # Pattern to match both @deprecated and @deprecated_kwargs
+    decorator_pattern = r"@deprecated(?:_kwargs)?"
     version_pattern = r"[v]?(\d+\.\d+\.\d+)"
 
     package_dir = Path(__file__).parent.parent / "jaxley"
+    project_root = Path(__file__).parent.parent
 
     violations = []
     for py_file in package_dir.rglob("*.py"):
@@ -31,8 +32,9 @@ def test_rm_all_deprecated_functions():
                         depr_version = np.array(
                             [int(s) for s in depr_version_str.split(".")]
                         )
-                        if not np.all(package_version <= depr_version):
-                            violations.append(f"{py_file}:L{line_num}")
+                        if np.all(depr_version <= package_version):
+                            relative_path = py_file.relative_to(project_root)
+                            violations.append(f"{relative_path}:L{line_num}")
 
     assert not violations, "\n".join(
         ["Found deprecated items that should have been removed:", *violations]

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -16,7 +16,7 @@ branch = jx.Branch(comp, 4)
 cell = jx.Cell([branch] * 3, [-1, 0, 0])
 net = jx.Network([cell] * 2)
 fname = os.path.join(os.path.dirname(__file__), "swc_files", "morph.swc")
-morph_cell = jx.read_swc(fname, nseg=1, max_branch_len=2_000, assign_groups=True)
+morph_cell = jx.read_swc(fname, ncomp=1, max_branch_len=2_000, assign_groups=True)
 
 # insert mechanisms
 net.cell(0).branch("all").insert(HH())

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -178,7 +178,7 @@ def build_net(num_cells, artificial=True, connect=True, connection_prob=0.0):
     else:
         dirname = os.path.dirname(__file__)
         fname = os.path.join(dirname, "swc_files", "morph.swc")
-        cell = jx.read_swc(fname, nseg=4)
+        cell = jx.read_swc(fname, ncomp=4)
     net = jx.Network([cell for _ in range(num_cells)])
 
     # Channels.


### PR DESCRIPTION
Deprecation helper should have raised when bumping the version, but did not trigger. This fixes that, deprecates nseg and bumps the version to `0.6.1`.

 

