### PR TITLE
Make sphinx configuration file explicit

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@
 # RTD configuration file version
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-22.04
   tools:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.1
+
+- Fixup for failing readthedocs build of v0.6.0 (#579, @michaeldeistler).
+
+
 # 0.6.0
 
 ### Pin of JAX version


### PR DESCRIPTION
The most recent readthedocs documentation (v0.6.0) did not build because we now require an explicit reference to the sphinx config file. See [here](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) for more info.

With this change, v0.6.1 should build successfully.