### PR TITLE
make github release before pypi

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -118,12 +118,6 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Upload to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
-
       - name: Extract changelog entry
         id: changelog
         run: |
@@ -141,3 +135,9 @@ jobs:
           tag_name: v${{ steps.get_version.outputs.version }}
           body_path: release_notes.txt
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*


### PR DESCRIPTION
Noticed that the pypi upload failed when merging #594. thought making the github release before pushing to pypi might be a bit more convenient, since if that fails, the github release can still be made successfully.