### PR TITLE
Allow `.distance` to be jitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - make `delta` and `v_th` in `IonotropicSynapse` trainable parameters (#599, @jnsbck)
 
+### Bug fixes
+
+- allow `.distance` to be jitted (#603, @michaeldeistler)
+
 
 # 0.7.0
 

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1211,9 +1211,9 @@ class Module(ABC):
             endpoint: The compartment to which to compute the distance to.
         """
         assert len(self.xyzr) == 1 and len(endpoint.xyzr) == 1
-        start_xyz = np.mean(self.xyzr[0][:, :3], axis=0)
-        end_xyz = np.mean(endpoint.xyzr[0][:, :3], axis=0)
-        return np.sqrt(np.sum((start_xyz - end_xyz) ** 2))
+        start_xyz = jnp.mean(self.xyzr[0][:, :3], axis=0)
+        end_xyz = jnp.mean(endpoint.xyzr[0][:, :3], axis=0)
+        return jnp.sqrt(jnp.sum((start_xyz - end_xyz) ** 2))
 
     def delete_trainables(self):
         """Removes all trainable parameters from the module."""


### PR DESCRIPTION
The following does not work in `JAX`:
```python
@jit
def mytest(param):
    return np.sqrt(np.sum(param * np.asarray([3.0, 4.0])))
mytest(jnp.ones((1,)))
```

To make this work, one needs:
```python
@jit
def mytest(param):
    return jnp.sqrt(jnp.sum(param * np.asarray([3.0, 4.0])))
mytest(jnp.ones((1,)))
```

This caused our `.distance()` to break within a `jit`. This PR fixes it.