### PR TITLE
Bugfix: allow ion diffusion to be jitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.8.2
 
 - enable intersections of groups, e.g. `net.exc.soma` (#608, @michaeldeistler)
+- allow ion diffusion to be jitted (#609, @michaeldeistler)
 
 
 # 0.8.1

--- a/docs/tutorials/11_ion_dynamics.ipynb
+++ b/docs/tutorials/11_ion_dynamics.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e2fa5fab",
+   "id": "3425db1c",
    "metadata": {},
    "source": [
     "# Ion dynamics\n",
@@ -16,7 +16,7 @@
     "Here is a code snippet which you will learn to understand in this tutorial:\n",
     "```python\n",
     "import jaxley as jx\n",
-    "from jaxley.channels import CaPump, CaNernstPotential\n",
+    "from jaxley.pumps import CaPump, CaNernstReversal\n",
     "from jaxley_mech.channels.l5pc import CaHVA\n",
     "\n",
     "\n",
@@ -30,7 +30,7 @@
     "cell.insert(CaPump())\n",
     "\n",
     "# Insert a mechanism that updates the calcium reversal potential based on the intracellular calcium level.\n",
-    "cell.insert(CaNernstPotential())\n",
+    "cell.insert(CaNernstReversal())\n",
     "\n",
     "# Let the intracellular calcium diffuse within the cell.\n",
     "cell.diffuse(\"CaCon_i\")\n",
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f77875e9",
+   "id": "e649a419",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3782763",
+   "id": "9526c5f6",
    "metadata": {},
    "source": [
     "First, we define a cell as you saw in the [previous tutorial](https://jaxley.readthedocs.io/en/latest/tutorials/01_morph_neurons.html) and insert sodium, potassium, and leak ion channels:"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8695b0fd",
+   "id": "e2c23319",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b36d3bf2",
+   "id": "dd8ff544",
    "metadata": {},
    "source": [
     "In this tutorial, we will set up a neuron with detailed calcium dynamcis. We will define all channels and pumps from scratch, but you could also just import these channels and run:\n",
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02e4964f",
+   "id": "3b106565",
    "metadata": {},
    "source": [
     "### A voltage-gated calcium channel\n",
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b40ba589",
+   "id": "45ebfced",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d8cd0f8",
+   "id": "9b6a66b0",
    "metadata": {},
    "source": [
     "Note two things:\n",
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d9d5e8d9",
+   "id": "158e5d80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7cba1f8",
+   "id": "09c9ec6d",
    "metadata": {},
    "source": [
     "### A calcium ion pump\n",
@@ -220,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "6946b6b7",
+   "id": "7d8f513c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cac61c6",
+   "id": "d46838eb",
    "metadata": {},
    "source": [
     "As you can see, the `CaPump` defines an `ion_name`:\n",
@@ -288,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "eb23e3a9",
+   "id": "3ceaf86d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b387ca72",
+   "id": "1a5b960b",
    "metadata": {},
    "source": [
     "If you do not want mechanisms such as calcium buffering (which are included in the model above), but you simply want to convert the calcium current to a change in intracellular concentration, use:\n",
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f86823da",
+   "id": "32faf49d",
    "metadata": {},
    "source": [
     "### Updating the calcium reversal potential"
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a3988c8",
+   "id": "f34ea8fb",
    "metadata": {},
    "source": [
     "The `CaPump` modifies the intracellular calcium ion concentration. So far, however, updating the intracellular calcium ion concentration does not impact the voltage dynamics at all (feel free to check the `CaHVA` channel above: neither its `update_states()` nor its `compute_current()` directly depend on `states[\"CaCon_i\"]`). To change this, we would like to modify the calcium reversal potential `eCa` based on the intracellular calcium concentration (again, check the `CaHVA` channel: its `compute_current()` _does_ depend on `states[\"eCa\"]`).\n",
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "1fc8b669",
+   "id": "8ffa9b5b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e039d16c",
+   "id": "ae05b650",
    "metadata": {},
    "source": [
     "The `CaNernstReversal` modifies the reversal potential `eCa` in its `update_states` method.\n",
@@ -382,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f871f513",
+   "id": "d17fcae8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b19aa77",
+   "id": "9c63a25f",
    "metadata": {},
    "source": [
     "### Ion diffusion"
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba6a8958",
+   "id": "ab331ffb",
    "metadata": {},
    "source": [
     "In principle, we could already run this simulation. Optionally, we can add one more feature: ion diffusion. Ion diffusion can be turned on with the `.diffuse()` method in `Jaxley` (if you do not run the `.diffuse()` method, then ions do not diffuse). In this case, we would like to diffuse the intracellular calcium concentration:"
@@ -408,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "7376aed5",
+   "id": "467e7ecb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83418af4",
+   "id": "0ae23931",
    "metadata": {},
    "source": [
     "We can define how strongly calcium diffuses by setting its axial resistivity:"
@@ -426,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f24f8868",
+   "id": "98a149e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +435,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52ea8bba",
+   "id": "954f9b42",
+   "metadata": {},
+   "source": [
+    "> **⚠️ IMPORTANT!**  \n",
+    "> `axial_diffusion_CaCon_i` must be strictly positive in the entire cell. We do not allow `0.0`, but you can use small values like `1e-8`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ffc0e27",
    "metadata": {},
    "source": [
     "### Running the simulation"
@@ -443,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23aafef4",
+   "id": "84ef4a78",
    "metadata": {},
    "source": [
     "We can now record voltage or intracellular calcium concentration from our cell, stimulate it with a step current, and simulate:"
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "61976366",
+   "id": "0ab9c460",
    "metadata": {},
    "outputs": [
     {
@@ -481,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "93aacb52",
+   "id": "6e7ba5a1",
    "metadata": {},
    "outputs": [
     {
@@ -506,7 +515,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a6b3417",
+   "id": "51dddb09",
    "metadata": {},
    "source": [
     "That's it! In this tutorial, you should have learned how to model detailed intracellular ion (in particular calcium) dynamics."

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -876,6 +876,14 @@ class Module(ABC):
             val: The value to set the parameter to. If it is `jnp.ndarray` then it
                 must be of shape `(len(num_compartments))`.
         """
+        if key in [f"axial_diffusion_{ion_name}" for ion_name in self.diffusion_states]:
+            assert val > 0, (
+                f"You are trying to set `{key}` to `{val}`. "
+                f"We only allow strictly positive values for the "
+                f"diffusion. Zero is not allowed either, but you can use very small "
+                f"values (e.g. 1e-8)."
+            )
+
         if key in self.nodes.columns:
             not_nan = ~self.nodes[key].isna().to_numpy()
             self.base.nodes.loc[self._nodes_in_view[not_nan], key] = val
@@ -1379,14 +1387,6 @@ class Module(ABC):
                 # `.set()` to work. This is done with `[:, None]`.
                 params[key] = params[key].at[inds].set(set_param[:, None])
 
-        for ion_name in self.diffusion_states:
-            minimal_diffusion = np.min(params[f"axial_diffusion_{ion_name}"])
-            assert minimal_diffusion > 0, (
-                f"The smallest value of `axial_diffusion_{ion_name}` is "
-                f"{minimal_diffusion}. We only allow strictly positive values for the "
-                f"diffusion. Zero is not allowed either, but you can use very small "
-                f"values (e.g. 1e-8)."
-            )
         # Compute conductance params and add them to the params dictionary.
         params["axial_conductances"] = self.base._compute_axial_conductances(
             params=params


### PR DESCRIPTION
The assert within `get_all_parameters()` broke because this function gets `jit`ted. We now move the assert to `.set()`. This might cause issues if the user uses `data_set()`, but I also left a very vocal warning on the tutorial notebook.

JAX's `checkify` did not work out of the box.