### PR TITLE
View tracks ._comp_edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - improvements to graph-backend for more flexibility in modifying morphologies (#613, @michaeldeistler)
 - remove root compartment for SWC files (#613, @michaeldeistler)
 - enable traversing compartmentalized graph for optimizing solve order (#613, @michaeldeistler)
+- `.comp_edges` are being tracked in the `View` (#621, @michaeldeistler)
 
 
 # 0.8.2

--- a/jaxley/modules/branch.py
+++ b/jaxley/modules/branch.py
@@ -124,5 +124,8 @@ class Branch(Module):
         self._indices_jax_spsolve = indices
         self._indptr_jax_spsolve = indptr
 
+        # To enable updating `self._comp_edges` during `View`.
+        self._comp_edges_in_view = self._comp_edges.index.to_numpy()
+
     def __len__(self) -> int:
         return self.ncomp

--- a/jaxley/modules/cell.py
+++ b/jaxley/modules/cell.py
@@ -108,6 +108,7 @@ class Cell(Module):
             np.arange(self.total_nbranches), self.ncomp_per_branch
         ).tolist()
         self.nodes["global_cell_index"] = np.repeat(0, self.cumsum_ncomp[-1]).tolist()
+
         self._update_local_indices()
         self._init_view()
 
@@ -271,3 +272,6 @@ class Cell(Module):
         self._data_inds = data_inds
         self._indices_jax_spsolve = indices
         self._indptr_jax_spsolve = indptr
+
+        # To enable updating `self._comp_edges` during `View`.
+        self._comp_edges_in_view = self._comp_edges.index.to_numpy()

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -93,3 +93,6 @@ class Compartment(Module):
         self._data_inds = data_inds
         self._indices_jax_spsolve = indices
         self._indptr_jax_spsolve = indptr
+
+        # To enable updating `self._comp_edges` during `View`.
+        self._comp_edges_in_view = self._comp_edges.index.to_numpy()

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -240,6 +240,9 @@ class Network(Module):
         self._indices_jax_spsolve = indices
         self._indptr_jax_spsolve = indptr
 
+        # To enable updating `self._comp_edges` during `View`.
+        self._comp_edges_in_view = self._comp_edges.index.to_numpy()
+
     def _step_synapse(
         self,
         states: Dict,


### PR DESCRIPTION
After this PR, `._comp_edges` gets updated in `View`:
```python
cell.branch(1).loc(0.0)._comp_edges
```

This PR also introduces a few special rules for this:
- for `cell.branch(1)` all edges to neighboring branchpoints are included.
- for `cell.branch(1).comp(0)` no edges to branchpoints are included.
- for `cell.branch(1).loc(0.0)` edges to the parent branchpoint are included.
- for `cell.branch(1).loc(1.0)` edges to the child branchpoint are included.

Why do we need these special rules? For modifying a morphology, we need some method to indicate to which end of a branch we want to attach another morphology. Consider the case where all branches have 1 compartment. Then:
`morph_attach(cell.branch(0).comp(0), new_morph)` would not know whether to attach the `new_morph` at the end or at the beginning of the `comp(0)`. This is now possible by simply distinguishing between
- `morph_attach(cell.branch(0).loc(0.0), new_morph)`
- `morph_attach(cell.branch(0).loc(1.0), new_morph)`