### PR TITLE
fix how `_current_view` is determined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.1
+
+### Fixes
+- Fix inheriting from a Module (#590, @jnsbck)
+
 # 0.9.0
 
 ### ✨ Highlights

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -343,8 +343,10 @@ class Module(ABC):
         """Init attributes critical for View.
 
         Needs to be called at init of a Module."""
-        parent = self.__class__.__name__.lower()
-        self._current_view = "comp" if parent == "compartment" else parent
+        modules = ["compartment", "branch", "cell", "network"]
+        module_inheritance = [c.__name__.lower() for c in self.__class__.__mro__]
+        module_type = next((t for t in modules if t in module_inheritance), None)
+        self._current_view = "comp" if module_type == "compartment" else module_type
         self._nodes_in_view = self.nodes.index.to_numpy()
         self._edges_in_view = self.edges.index.to_numpy()
 

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -657,3 +657,33 @@ def test_comp_edge_indexing(SimpleCell, ncomp: int):
         2 * ncomp - 1
         not in cell.branch(1).loc(0.0)._comp_edges["sink"].to_numpy().tolist()
     )
+
+def test_module_inheritance():
+    """Test inheritance of modules works properly. (see #590)"""
+    class CustomCompartment(jx.Compartment):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    class CustomBranch(jx.Branch):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    class CustomCell(jx.Cell):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    class CustomNetwork(jx.Network):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    class CustomChildNetwork(CustomNetwork):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    custom_comp = CustomCompartment()
+    custom_branch = CustomBranch(custom_comp, ncomp=3)
+    custom_cell = CustomCell([custom_branch], [-1])
+    custom_network = CustomNetwork([custom_cell])
+    custom_child_network = CustomChildNetwork([custom_cell])
+    
+    custom_child_network.cell(0).branch(0).comp(0).nodes

--- a/tests/test_viewing.py
+++ b/tests/test_viewing.py
@@ -658,8 +658,10 @@ def test_comp_edge_indexing(SimpleCell, ncomp: int):
         not in cell.branch(1).loc(0.0)._comp_edges["sink"].to_numpy().tolist()
     )
 
+
 def test_module_inheritance():
     """Test inheritance of modules works properly. (see #590)"""
+
     class CustomCompartment(jx.Compartment):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -685,5 +687,5 @@ def test_module_inheritance():
     custom_cell = CustomCell([custom_branch], [-1])
     custom_network = CustomNetwork([custom_cell])
     custom_child_network = CustomChildNetwork([custom_cell])
-    
+
     custom_child_network.cell(0).branch(0).comp(0).nodes


### PR DESCRIPTION
Fixes #590 and adds test to check for this in the future. 

I tried to avoid adding more attributes to the module class. The simpler solution would have been to add a `name` attr to each `Module` that could have been checked and is not overwritten by class inheritance like `__class__.__name__`. 

If you prefer this let me know.