### PR TITLE
Synapse recording indices bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.1
+
+### 🐛 Bug fixes
+
+- fixed synapse recording indices to be within type (@kyralianaka)
+
 # 0.9.0
 
 ### ✨ Highlights

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -144,6 +144,7 @@ class Module(ABC):
         self.edges = pd.DataFrame(
             columns=[
                 "global_edge_index",
+                "index_within_type",
                 "pre_index",
                 "post_index",
                 "pre_locs",
@@ -1822,9 +1823,14 @@ class Module(ABC):
 
     def record(self, state: str = "v", verbose=True):
         comp_states, edge_states = self._get_state_names()
-        if state not in comp_states + edge_states:
+        if state in comp_states:
+            in_view = self._nodes_in_view
+        elif state in edge_states:
+            in_view = self.base.edges.iloc[
+                self._edges_in_view.tolist()
+            ].index_within_type.to_numpy(dtype=int)
+        else:
             raise KeyError(f"{state} is not a recognized state in this module.")
-        in_view = self._nodes_in_view if state in comp_states else self._edges_in_view
 
         new_recs = pd.DataFrame(in_view, columns=["rec_index"])
         new_recs["state"] = state

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -526,10 +526,16 @@ class Network(Module):
         if is_new:  # synapse is not known
             self._update_synapse_state_names(synapse_type)
             self.base.synapse_current_names.append(synapse_current_name)
+            index_within_type = list(range(0, len(pre_nodes)))
+        else:
+            # Figure out how many synapses of this type already exist
+            n_existing = len(self.base.edges[self.base.edges.type == synapse_name])
+            index_within_type = list(range(n_existing, n_existing + len(pre_nodes)))
 
         index = len(self.base.edges)
         indices = [idx for idx in range(index, index + len(pre_nodes))]
         global_edge_index = pd.DataFrame({"global_edge_index": indices})
+        index_within_type = pd.DataFrame({"index_within_type": index_within_type})
         post_loc = loc_of_index(
             post_nodes["global_comp_index"].to_numpy(),
             post_nodes["global_branch_index"].to_numpy(),
@@ -547,6 +553,7 @@ class Network(Module):
         new_rows = pd.concat(
             [
                 global_edge_index,
+                index_within_type,
                 pre_nodes.reset_index(drop=True),
                 post_nodes.reset_index(drop=True),
             ],


### PR DESCRIPTION
The test added in this pull request used to fail because the rec_index came from `self._edges_in_view` (indices from the whole edges dataframe) while jaxedges saves synapse states separately by synapse type (thanks for your investigation @michaeldeistler!). This then means that synapse states returned as the recordings were incorrect if their global edge index exceeded the number of edges of that synapse type. In this case the recording would have mirrored the last synapse state timecourse within range.

People who use multiple synapse types and record synapse states would have been strongly affected. 

