### PR TITLE
Pathwise distance between compartments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
-# 0.9.1
+# 0.10.0 (pre-release)
+
+### 🧩 New features
+
+- functionality to compute the pathwise distance between compartments (#648,
+@michaeldeistler):
+```python
+from jaxley.morphology import distance
+path_dists = distance(cell.soma.branch(0).comp(0), cell)
+cell.nodes["path_dist_from_soma"] = path_dists
+```
 
 ### 🐛 Bug fixes
 
 - fixed synapse recording indices to be within type (#643, @kyralianaka)
 - Fix inheriting from a Module #590 (#642, @jnsbck)
+
+### 🛠️ Internal updates
+
+- `module.distance()` is now deprecated in favor of `jx.morphology.distance()` (#648,
+@michaeldeistler)
+
 
 # 0.9.0
 
@@ -49,6 +65,9 @@ runtime, see [here](https://github.com/jax-ml/jax/issues/26145) (#623, @michaeld
 ### 🛠️ Internal updates
 
 - improvements to graph-backend for more flexibility in modifying morphologies (#613,
+@michaeldeistler)
+- `jx.read_swc()` now ignores `type_id > 4` by default. This ensures compatibility
+with flywire, which highjacks `type_id > 4` to indicate synaptic contacts (#612,
 @michaeldeistler)
 - remove root compartment for SWC files (#613, @michaeldeistler)
 - enable traversing compartmentalized graph for optimizing solve order (#613,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - functionality to compute the pathwise distance between compartments (#648,
 @michaeldeistler):
 ```python
-from jaxley.morphology import distance
-path_dists = distance(cell.soma.branch(0).comp(0), cell)
+from jaxley.morphology import distance_pathwise
+path_dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
 cell.nodes["path_dist_from_soma"] = path_dists
 ```
 
@@ -17,8 +17,8 @@ cell.nodes["path_dist_from_soma"] = path_dists
 
 ### 🛠️ Internal updates
 
-- `module.distance()` is now deprecated in favor of `jx.morphology.distance()` (#648,
-@michaeldeistler)
+- `module.distance()` is now deprecated in favor of `jx.morphology.distance_direct()`
+(#648, @michaeldeistler)
 
 
 # 0.9.0

--- a/docs/jaxley.rst
+++ b/docs/jaxley.rst
@@ -33,6 +33,7 @@ Morphologies
    :nosignatures:
 
    jaxley.read_swc
+   jaxley.morphology.distance
    jaxley.morphology.morph_delete
    jaxley.morphology.morph_connect
 

--- a/docs/jaxley.rst
+++ b/docs/jaxley.rst
@@ -33,7 +33,8 @@ Morphologies
    :nosignatures:
 
    jaxley.read_swc
-   jaxley.morphology.distance
+   jaxley.morphology.distance_direct
+   jaxley.morphology.distance_pathwise
    jaxley.morphology.morph_delete
    jaxley.morphology.morph_connect
 

--- a/docs/tutorials/08_importing_morphologies.ipynb
+++ b/docs/tutorials/08_importing_morphologies.ipynb
@@ -18,11 +18,18 @@
     "\n",
     "\n",
     "```python\n",
+    "import matplotlib.pyplot as plt\n",
     "import jaxley as jx\n",
     "from jaxley.morphology import morph_delete, morph_connect\n",
     "\n",
     "# Read cell from SWC.\n",
     "cell = jx.read_swc(\"my_cell.swc\", ncomp=1)\n",
+    "\n",
+    "# Visualize the cell.\n",
+    "cell.vis()\n",
+    "plt.axis(\"square\")\n",
+    "\n",
+    "# If needed, Jaxley provides utilities to edit cells, as shown below.\n",
     "\n",
     "# Delete the apical dendrite.\n",
     "cell = morph_delete(cell.apical)\n",
@@ -37,15 +44,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "import jaxley as jx"
+    "Let's get started!"
    ]
   },
   {
@@ -66,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -240,12 +242,14 @@
        "[155 rows x 6 columns]"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "import jaxley as jx\n",
+    "\n",
     "# import swc file into jx.Cell object\n",
     "fname = \"data/morph.swc\"\n",
     "cell = jx.read_swc(fname, ncomp=1)  # Use one compartment per branch. We modify this below.\n",
@@ -265,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -465,7 +469,7 @@
        "4                  4                    1  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -497,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -512,7 +516,8 @@
     }
    ],
    "source": [
-    "# visualize the cell\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
     "cell.vis()\n",
     "plt.axis(\"off\")\n",
     "plt.title(\"L5PC\")\n",
@@ -529,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -568,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -597,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -630,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -694,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -713,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -741,7 +746,7 @@
        "(-130.92000000000002, 152.44, -21.766, 205.186)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -776,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -864,7 +869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {

--- a/docs/tutorials/08_importing_morphologies.ipynb
+++ b/docs/tutorials/08_importing_morphologies.ipynb
@@ -25,7 +25,7 @@
     "# Read cell from SWC.\n",
     "cell = jx.read_swc(\"my_cell.swc\", ncomp=1)\n",
     "\n",
-    "# Visualize the cell.\n",
+    "# Plot the cell morphology.\n",
     "cell.vis()\n",
     "plt.axis(\"square\")\n",
     "\n",

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1457,10 +1457,21 @@ class Module(ABC):
             for key in list(synapse.synapse_states.keys()):
                 self.base.edges.loc[condition, key] = all_states[key]
 
+    @deprecated(
+        "v0.11.0",
+        (
+            " Instead, please use, e.g., "
+            "`jx.morphology_utils.distance_direct(cell[0, 0], cell[2, 1])`. "
+            "Note that, unlike `cell[0, 0].distance(cell[2, 1]), that "
+            "function returns a list of distances (to all endpoints)."
+        )
+    )
     def distance(self, endpoint: "View") -> float:
         """Return the direct distance between two compartments.
-        This does not compute the pathwise distance (which is currently not
-        implemented).
+        
+        This function computes the direct distance. To compute the pathwise distance,
+        use `distance_pathwise()`.
+
         Args:
             endpoint: The compartment to which to compute the distance to.
         """

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1464,11 +1464,11 @@ class Module(ABC):
             "`jx.morphology_utils.distance(cell[0, 0], cell[2, 1], kind='direct')`. "
             "Note that, unlike `cell[0, 0].distance(cell[2, 1]), that "
             "function returns a list of distances (to all endpoints)."
-        )
+        ),
     )
     def distance(self, endpoint: "View") -> float:
         """Return the direct distance between two compartments.
-        
+
         This function computes the direct distance. To compute the pathwise distance,
         use `distance_pathwise()`.
 

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1461,7 +1461,7 @@ class Module(ABC):
         "v0.11.0",
         (
             " Instead, please use, e.g., "
-            "`jx.morphology_utils.distance_direct(cell[0, 0], cell[2, 1])`. "
+            "`jx.morphology_utils.distance(cell[0, 0], cell[2, 1], kind='direct')`. "
             "Note that, unlike `cell[0, 0].distance(cell[2, 1]), that "
             "function returns a list of distances (to all endpoints)."
         )

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1458,7 +1458,7 @@ class Module(ABC):
                 self.base.edges.loc[condition, key] = all_states[key]
 
     @deprecated(
-        "v0.11.0",
+        "0.11.0",
         (
             " Instead, please use, e.g., "
             "`jx.morphology_utils.distance(cell[0, 0], cell[2, 1], kind='direct')`. "

--- a/jaxley/morphology/__init__.py
+++ b/jaxley/morphology/__init__.py
@@ -2,6 +2,6 @@
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 from jaxley.morphology.morph_utils import morph_connect, morph_delete
-from jaxley.morphology.distance_utils import distance_pathwise, distance_direct
+from jaxley.morphology.distance_utils import distance
 
-__all__ = ["morph_connect", "morph_delete", "distance_pathwise", "distance_direct"]
+__all__ = ["morph_connect", "morph_delete", "distance"]

--- a/jaxley/morphology/__init__.py
+++ b/jaxley/morphology/__init__.py
@@ -2,5 +2,6 @@
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 from jaxley.morphology.morph_utils import morph_connect, morph_delete
+from jaxley.morphology.distance_utils import distance_pathwise, distance_direct
 
-__all__ = ["morph_connect", "morph_delete"]
+__all__ = ["morph_connect", "morph_delete", "distance_pathwise", "distance_direct"]

--- a/jaxley/morphology/__init__.py
+++ b/jaxley/morphology/__init__.py
@@ -1,7 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from jaxley.morphology.distance_utils import distance
+from jaxley.morphology.distance_utils import distance_direct, distance_pathwise
 from jaxley.morphology.morph_utils import morph_connect, morph_delete
 
-__all__ = ["morph_connect", "morph_delete", "distance"]
+__all__ = ["morph_connect", "morph_delete", "distance_direct", "distance_pathwise"]

--- a/jaxley/morphology/__init__.py
+++ b/jaxley/morphology/__init__.py
@@ -1,7 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
-from jaxley.morphology.morph_utils import morph_connect, morph_delete
 from jaxley.morphology.distance_utils import distance
+from jaxley.morphology.morph_utils import morph_connect, morph_delete
 
 __all__ = ["morph_connect", "morph_delete", "distance"]

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -5,30 +5,8 @@ from jaxley.modules.base import to_graph
 import networkx as nx
 
 
-def distance_direct(startpoint: "View", endpoints: "View") -> float:
-    """Return the direct distance between two compartments.
-    
-    This function computes the direct distance. To compute the pathwise distance,
-    use `distance_pathwise()`.
-
-    Args:
-        startpoint: A single compartment from which to compute the distance.
-        endpoint: One or multiple compartments to which to compute the distance to.
-
-    Returns:
-        A list of distances.
-    """
-    assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
-    start_xyz = startpoint.nodes[["x", "y", "z"]].to_numpy()[0]
-    end_xyz = endpoints.nodes[["x", "y", "z"]].to_numpy()
-    return jnp.sqrt(jnp.sum((start_xyz - end_xyz) ** 2, axis=1))
-
-
-def distance_pathwise(startpoint: "View", endpoints: "View") -> List[float]:
-    """Return the pathwise distance between a root and several other compartments.
-
-    This function computes the pathwise distance. To compute the direct distance,
-    use `distance()`.
+def distance(startpoint: "View", endpoints: "View", kind="pathwise") -> List[float]:
+    """Return the distance (pathwise or direct) between a root and other compartments.
 
     This function uses Dijkstra's algorithm to get the path with the lowest number
     of compartments between start and endpoint. It then computes the length of
@@ -38,7 +16,7 @@ def distance_pathwise(startpoint: "View", endpoints: "View") -> List[float]:
 
     Args:
         startpoint: A single compartment from which to compute the distance.
-        endpoint: One or multiple compartments to which to compute the distance to.
+        endpoints: One or multiple compartments to which to compute the distance to.
 
     Returns:
         A list of distances.
@@ -46,53 +24,72 @@ def distance_pathwise(startpoint: "View", endpoints: "View") -> List[float]:
     Example usage
     ^^^^^^^^^^^^^
 
-    The following computes the pathwise distance between the zero-eth soma
+    Example 1: The following computes the pathwise distance between the zero-eth soma
     compartment and all other compartments. It then saves this distance in
-    `cell.nodes["dist_from_soma"]`.
+    `cell.nodes["path_dist_from_soma"]`.
 
     ::
 
-        dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
-        cell.nodes["dist_from_soma"] = dists
+        path_dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
+        cell.nodes["path_dist_from_soma"] = path_dists
 
-    The following computes the pathwise distance between two compartments.
+    Example 2: The following computes the pathwise distance between two compartments.
 
     ::
 
         dist = distance_pathwise(cell.branch(8).comp(2), cell.branch(2).comp(0))
+
+    Example 3: The following computes the direct (line of sight) distance between the
+    zero-eth soma compartment and all other compartments. It then saves this distance
+    in `cell.nodes["direct_dist_from_soma"]`.
+
+    ::
+
+        direct_dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
+        cell.nodes["direct_dist_from_soma"] = direct_dists
     """
     assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
-    root = startpoint.nodes.index[0]
 
-    endpoint_inds = endpoints.nodes.index
+    if kind == "direct":
+        start_xyz = startpoint.nodes[["x", "y", "z"]].to_numpy()[0]
+        end_xyz = endpoints.nodes[["x", "y", "z"]].to_numpy()
+        return jnp.sqrt(jnp.sum((start_xyz - end_xyz) ** 2, axis=1))
 
-    graph = to_graph(startpoint.base)
-    graph = nx.to_undirected(graph)
+    elif kind == "pathwise":
+        root = startpoint.nodes.index[0]
+        endpoint_inds = endpoints.nodes.index
+        graph = to_graph(startpoint.base)
+        graph = nx.to_undirected(graph)
 
-    # Set default for branchpoints.
-    for _, data in graph.nodes(data=True):
-        data.setdefault("length", 0.0)
+        # Set default for branchpoints.
+        for _, data in graph.nodes(data=True):
+            data.setdefault("length", 0.0)
 
-    def custom_path_length(graph: nx.Graph, path: List):
-        """Compute total path length, counting root and target node lengths as half.
+        def custom_path_length(graph: nx.Graph, path: List):
+            """Compute total path length, counting root and target node lengths as half.
 
-        Args:
-            G (nx.Graph): Graph with node attribute "length".
-            path (list): List of node IDs representing the path.
+            Args:
+                G (nx.Graph): Graph with node attribute "length".
+                path (list): List of node IDs representing the path.
 
-        Returns:
-            float: Adjusted total path length.
-        """
-        if not path:
-            return 0
-        length = sum(graph.nodes[n]["length"] for n in path)
-        length -= 0.5 * graph.nodes[path[0]]["length"]  # subtract half root
-        length -= 0.5 * graph.nodes[path[-1]]["length"]  # subtract half target
-        return length
+            Returns:
+                float: Adjusted total path length.
+            """
+            if not path:
+                return 0
+            length = sum(graph.nodes[n]["length"] for n in path)
+            length -= 0.5 * graph.nodes[path[0]]["length"]  # subtract half root
+            length -= 0.5 * graph.nodes[path[-1]]["length"]  # subtract half target
+            return length
 
-    # Use Dijkstra to minimum adjusted length from root to all endpoint nodes.
-    lengths = []
-    for endpoint in endpoint_inds:
-        path = nx.shortest_path(graph, root, endpoint)
-        lengths.append(custom_path_length(graph, path))
-    return lengths
+        # Use Dijkstra to minimum adjusted length from root to all endpoint nodes.
+        lengths = []
+        for endpoint in endpoint_inds:
+            path = nx.shortest_path(graph, root, endpoint)
+            lengths.append(custom_path_length(graph, path))
+        return lengths
+
+    else:
+        raise ValueError(
+            f"`kind` must be either of `pathwise` or `direct`, but you passed `{kind}`"
+        )

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -15,7 +15,7 @@ def distance_direct(
 ) -> List[float]:
     """Returns the direct distance between a root and other compartments.
 
-    This function uses `cell.nodes[['x', 'y', 'z']]` and computes the euclidean
+    This function uses ``cell.nodes[['x', 'y', 'z']]`` and computes the euclidean
     distance (i.e., the line of sight distance).
 
     Args:
@@ -33,6 +33,8 @@ def distance_direct(
     in `cell.nodes["direct_dist_from_soma"]`.
 
     ::
+
+        from jaxley.morphology import distance_pathwise
 
         cell.compute_compartment_centers()  # necessary if you modified branch length.
         direct_dists = distance_direct(cell.soma.branch(0).comp(0), cell)

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -5,18 +5,23 @@ from jaxley.modules.base import to_graph
 import networkx as nx
 
 
-def distance(startpoint: "View", endpoints: "View", kind="pathwise") -> List[float]:
+def distance(
+    startpoint: "View", endpoints: Union["Module", "View"], kind: str = "pathwise"
+) -> List[float]:
     """Return the distance (pathwise or direct) between a root and other compartments.
-
-    This function uses Dijkstra's algorithm to get the path with the lowest number
-    of compartments between start and endpoint. It then computes the length of
-    that path in micrometers. Note that, for an uncyclic graph, the path with the
-    lowest number of compartments between start and endpoint is also the path
-    with the lowest length.
 
     Args:
         startpoint: A single compartment from which to compute the distance.
         endpoints: One or multiple compartments to which to compute the distance to.
+        kind: Either of 'pathwise' or 'direct'. If 'pathwise', it computes the
+            shortest path distance between two compartments. If 'direct', it computes
+            the direct (line of sight) distance between two compartments. For
+            'pathwise', we use Dijkstra's algorithm to get the path with the lowest
+            number of compartments between start and endpoint. It then computes the
+            length of that path in micrometers. Note that, for an uncyclic graph, the
+            path with the lowest number of compartments between start and endpoint is
+            also the path with the lowest length. For 'direct', we use
+            `cell.nodes[['x', 'y', 'z']]` and compute the euclidean distance.
 
     Returns:
         A list of distances.
@@ -30,14 +35,14 @@ def distance(startpoint: "View", endpoints: "View", kind="pathwise") -> List[flo
 
     ::
 
-        path_dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
+        path_dists = distance(cell.soma.branch(0).comp(0), cell)
         cell.nodes["path_dist_from_soma"] = path_dists
 
     Example 2: The following computes the pathwise distance between two compartments.
 
     ::
 
-        dist = distance_pathwise(cell.branch(8).comp(2), cell.branch(2).comp(0))
+        dist = distance(cell.branch(8).comp(2), cell.branch(2).comp(0))
 
     Example 3: The following computes the direct (line of sight) distance between the
     zero-eth soma compartment and all other compartments. It then saves this distance
@@ -45,7 +50,7 @@ def distance(startpoint: "View", endpoints: "View", kind="pathwise") -> List[flo
 
     ::
 
-        direct_dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
+        direct_dists = distance(cell.soma.branch(0).comp(0), cell, kind='direct')
         cell.nodes["direct_dist_from_soma"] = direct_dists
     """
     assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -13,10 +13,10 @@ def distance_direct(
     startpoint: "View",
     endpoints: Union["Branch", "Cell", "View"],
 ) -> List[float]:
-    """Return the direct (line of sight) distance between a root and other compartments.
+    """Returns the direct distance between a root and other compartments.
 
     This function uses `cell.nodes[['x', 'y', 'z']]` and computes the euclidean
-    distance.
+    distance (i.e., the line of sight distance).
 
     Args:
         startpoint: A single compartment from which to compute the distance.
@@ -35,7 +35,7 @@ def distance_direct(
     ::
 
         cell.compute_compartment_centers()  # necessary if you modified branch length.
-        direct_dists = distance(cell.soma.branch(0).comp(0), cell, kind='direct')
+        direct_dists = distance_direct(cell.soma.branch(0).comp(0), cell)
         cell.nodes["direct_dist_from_soma"] = direct_dists
     """
     assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
@@ -72,16 +72,16 @@ def distance_pathwise(
 
     ::
 
-        from jaxley.morphology import distance
+        from jaxley.morphology import distance_pathwise
 
-        path_dists = distance(cell.soma.branch(0).comp(0), cell)
+        path_dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
         cell.nodes["path_dist_from_soma"] = path_dists
 
     Example 2: The following computes the pathwise distance between two compartments.
 
     ::
 
-        dist = distance(cell.branch(8).comp(2), cell.branch(2).comp(0))
+        dist = distance_pathwise(cell.branch(8).comp(2), cell.branch(2).comp(0))
     """
     assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
 

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -1,8 +1,12 @@
-import jax.numpy as jnp
+# This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
+# licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
 from typing import List, Union
-from jaxley.modules.base import to_graph
+
+import jax.numpy as jnp
 import networkx as nx
+
+from jaxley.modules.base import to_graph
 
 
 def distance(
@@ -54,6 +58,7 @@ def distance(
 
     ::
 
+        cell.compute_compartment_centers()  # necessary if you modified branch length.
         direct_dists = distance(cell.soma.branch(0).comp(0), cell, kind='direct')
         cell.nodes["direct_dist_from_soma"] = direct_dists
     """
@@ -74,15 +79,15 @@ def distance(
         for _, data in graph.nodes(data=True):
             data.setdefault("length", 0.0)
 
-        def custom_path_length(graph: nx.Graph, path: List):
+        def custom_path_length(graph: nx.Graph, path: List) -> float:
             """Compute total path length, counting root and target node lengths as half.
 
             Args:
-                G (nx.Graph): Graph with node attribute "length".
-                path (list): List of node IDs representing the path.
+                graph:: Graph with node attribute "length".
+                path: List of node IDs representing the path.
 
             Returns:
-                float: Adjusted total path length.
+                Adjusted total path length.
             """
             if not path:
                 return 0

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -1,12 +1,14 @@
 import jax.numpy as jnp
 
-from typing import List
+from typing import List, Union
 from jaxley.modules.base import to_graph
 import networkx as nx
 
 
 def distance(
-    startpoint: "View", endpoints: Union["Module", "View"], kind: str = "pathwise"
+    startpoint: "View",
+    endpoints: Union["Branch", "Cell", "View"],
+    kind: str = "pathwise",
 ) -> List[float]:
     """Return the distance (pathwise or direct) between a root and other compartments.
 
@@ -34,6 +36,8 @@ def distance(
     `cell.nodes["path_dist_from_soma"]`.
 
     ::
+
+        from jaxley.morphology import distance
 
         path_dists = distance(cell.soma.branch(0).comp(0), cell)
         cell.nodes["path_dist_from_soma"] = path_dists

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -1,0 +1,98 @@
+import jax.numpy as jnp
+
+from typing import List
+from jaxley.modules.base import to_graph
+import networkx as nx
+
+
+def distance_direct(startpoint: "View", endpoints: "View") -> float:
+    """Return the direct distance between two compartments.
+    
+    This function computes the direct distance. To compute the pathwise distance,
+    use `distance_pathwise()`.
+
+    Args:
+        startpoint: A single compartment from which to compute the distance.
+        endpoint: One or multiple compartments to which to compute the distance to.
+
+    Returns:
+        A list of distances.
+    """
+    assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
+    start_xyz = startpoint.nodes[["x", "y", "z"]].to_numpy()[0]
+    end_xyz = endpoints.nodes[["x", "y", "z"]].to_numpy()
+    return jnp.sqrt(jnp.sum((start_xyz - end_xyz) ** 2, axis=1))
+
+
+def distance_pathwise(startpoint: "View", endpoints: "View") -> List[float]:
+    """Return the pathwise distance between a root and several other compartments.
+
+    This function computes the pathwise distance. To compute the direct distance,
+    use `distance()`.
+
+    This function uses Dijkstra's algorithm to get the path with the lowest number
+    of compartments between start and endpoint. It then computes the length of
+    that path in micrometers. Note that, for an uncyclic graph, the path with the
+    lowest number of compartments between start and endpoint is also the path
+    with the lowest length.
+
+    Args:
+        startpoint: A single compartment from which to compute the distance.
+        endpoint: One or multiple compartments to which to compute the distance to.
+
+    Returns:
+        A list of distances.
+
+    Example usage
+    ^^^^^^^^^^^^^
+
+    The following computes the pathwise distance between the zero-eth soma
+    compartment and all other compartments. It then saves this distance in
+    `cell.nodes["dist_from_soma"]`.
+
+    ::
+
+        dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
+        cell.nodes["dist_from_soma"] = dists
+
+    The following computes the pathwise distance between two compartments.
+
+    ::
+
+        dist = distance_pathwise(cell.branch(8).comp(2), cell.branch(2).comp(0))
+    """
+    assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
+    root = startpoint.nodes.index[0]
+
+    endpoint_inds = endpoints.nodes.index
+
+    graph = to_graph(startpoint.base)
+    graph = nx.to_undirected(graph)
+
+    # Set default for branchpoints.
+    for _, data in graph.nodes(data=True):
+        data.setdefault("length", 0.0)
+
+    def custom_path_length(graph: nx.Graph, path: List):
+        """Compute total path length, counting root and target node lengths as half.
+
+        Args:
+            G (nx.Graph): Graph with node attribute "length".
+            path (list): List of node IDs representing the path.
+
+        Returns:
+            float: Adjusted total path length.
+        """
+        if not path:
+            return 0
+        length = sum(graph.nodes[n]["length"] for n in path)
+        length -= 0.5 * graph.nodes[path[0]]["length"]  # subtract half root
+        length -= 0.5 * graph.nodes[path[-1]]["length"]  # subtract half target
+        return length
+
+    # Use Dijkstra to minimum adjusted length from root to all endpoint nodes.
+    lengths = []
+    for endpoint in endpoint_inds:
+        path = nx.shortest_path(graph, root, endpoint)
+        lengths.append(custom_path_length(graph, path))
+    return lengths

--- a/jaxley/morphology/distance_utils.py
+++ b/jaxley/morphology/distance_utils.py
@@ -9,25 +9,56 @@ import networkx as nx
 from jaxley.modules.base import to_graph
 
 
-def distance(
+def distance_direct(
     startpoint: "View",
     endpoints: Union["Branch", "Cell", "View"],
-    kind: str = "pathwise",
 ) -> List[float]:
-    """Return the distance (pathwise or direct) between a root and other compartments.
+    """Return the direct (line of sight) distance between a root and other compartments.
+
+    This function uses `cell.nodes[['x', 'y', 'z']]` and computes the euclidean
+    distance.
 
     Args:
         startpoint: A single compartment from which to compute the distance.
         endpoints: One or multiple compartments to which to compute the distance to.
-        kind: Either of 'pathwise' or 'direct'. If 'pathwise', it computes the
-            shortest path distance between two compartments. If 'direct', it computes
-            the direct (line of sight) distance between two compartments. For
-            'pathwise', we use Dijkstra's algorithm to get the path with the lowest
-            number of compartments between start and endpoint. It then computes the
-            length of that path in micrometers. Note that, for an uncyclic graph, the
-            path with the lowest number of compartments between start and endpoint is
-            also the path with the lowest length. For 'direct', we use
-            `cell.nodes[['x', 'y', 'z']]` and compute the euclidean distance.
+
+    Returns:
+        A list of distances.
+
+    Example usage
+    ^^^^^^^^^^^^^
+
+    The following computes the direct (line of sight) distance between the
+    zero-eth soma compartment and all other compartments. It then saves this distance
+    in `cell.nodes["direct_dist_from_soma"]`.
+
+    ::
+
+        cell.compute_compartment_centers()  # necessary if you modified branch length.
+        direct_dists = distance(cell.soma.branch(0).comp(0), cell, kind='direct')
+        cell.nodes["direct_dist_from_soma"] = direct_dists
+    """
+    assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
+
+    start_xyz = startpoint.nodes[["x", "y", "z"]].to_numpy()[0]
+    end_xyz = endpoints.nodes[["x", "y", "z"]].to_numpy()
+    return jnp.sqrt(jnp.sum((start_xyz - end_xyz) ** 2, axis=1))
+
+
+def distance_pathwise(
+    startpoint: "View", endpoints: Union["Branch", "Cell", "View"]
+) -> List[float]:
+    """Returns the pathwise distance between a root and other compartments.
+
+    We use Dijkstra's algorithm to get the path with the lowest
+    number of compartments between start and endpoint. It then computes the
+    length of that path in micrometers. Note that, for an uncyclic graph, the
+    path with the lowest number of compartments between start and endpoint is
+    also the path with the lowest length.
+
+    Args:
+        startpoint: A single compartment from which to compute the distance.
+        endpoints: One or multiple compartments to which to compute the distance to.
 
     Returns:
         A list of distances.
@@ -51,59 +82,38 @@ def distance(
     ::
 
         dist = distance(cell.branch(8).comp(2), cell.branch(2).comp(0))
-
-    Example 3: The following computes the direct (line of sight) distance between the
-    zero-eth soma compartment and all other compartments. It then saves this distance
-    in `cell.nodes["direct_dist_from_soma"]`.
-
-    ::
-
-        cell.compute_compartment_centers()  # necessary if you modified branch length.
-        direct_dists = distance(cell.soma.branch(0).comp(0), cell, kind='direct')
-        cell.nodes["direct_dist_from_soma"] = direct_dists
     """
     assert len(startpoint.nodes.index) == 1, "Cannot use multiple root nodes."
 
-    if kind == "direct":
-        start_xyz = startpoint.nodes[["x", "y", "z"]].to_numpy()[0]
-        end_xyz = endpoints.nodes[["x", "y", "z"]].to_numpy()
-        return jnp.sqrt(jnp.sum((start_xyz - end_xyz) ** 2, axis=1))
+    root = startpoint.nodes.index[0]
+    endpoint_inds = endpoints.nodes.index
+    graph = to_graph(startpoint.base)
+    graph = nx.to_undirected(graph)
 
-    elif kind == "pathwise":
-        root = startpoint.nodes.index[0]
-        endpoint_inds = endpoints.nodes.index
-        graph = to_graph(startpoint.base)
-        graph = nx.to_undirected(graph)
+    # Set default for branchpoints.
+    for _, data in graph.nodes(data=True):
+        data.setdefault("length", 0.0)
 
-        # Set default for branchpoints.
-        for _, data in graph.nodes(data=True):
-            data.setdefault("length", 0.0)
+    def custom_path_length(graph: nx.Graph, path: List) -> float:
+        """Compute total path length, counting root and target node lengths as half.
 
-        def custom_path_length(graph: nx.Graph, path: List) -> float:
-            """Compute total path length, counting root and target node lengths as half.
+        Args:
+            graph:: Graph with node attribute "length".
+            path: List of node IDs representing the path.
 
-            Args:
-                graph:: Graph with node attribute "length".
-                path: List of node IDs representing the path.
+        Returns:
+            Adjusted total path length.
+        """
+        if not path:
+            return 0
+        length = sum(graph.nodes[n]["length"] for n in path)
+        length -= 0.5 * graph.nodes[path[0]]["length"]  # subtract half root
+        length -= 0.5 * graph.nodes[path[-1]]["length"]  # subtract half target
+        return length
 
-            Returns:
-                Adjusted total path length.
-            """
-            if not path:
-                return 0
-            length = sum(graph.nodes[n]["length"] for n in path)
-            length -= 0.5 * graph.nodes[path[0]]["length"]  # subtract half root
-            length -= 0.5 * graph.nodes[path[-1]]["length"]  # subtract half target
-            return length
-
-        # Use Dijkstra to minimum adjusted length from root to all endpoint nodes.
-        lengths = []
-        for endpoint in endpoint_inds:
-            path = nx.shortest_path(graph, root, endpoint)
-            lengths.append(custom_path_length(graph, path))
-        return lengths
-
-    else:
-        raise ValueError(
-            f"`kind` must be either of `pathwise` or `direct`, but you passed `{kind}`"
-        )
+    # Use Dijkstra to minimum adjusted length from root to all endpoint nodes.
+    lengths = []
+    for endpoint in endpoint_inds:
+        path = nx.shortest_path(graph, root, endpoint)
+        lengths.append(custom_path_length(graph, path))
+    return lengths

--- a/jaxley/morphology/morph_utils.py
+++ b/jaxley/morphology/morph_utils.py
@@ -84,7 +84,7 @@ def morph_delete(module_view) -> "Cell":
 
 
 def morph_connect(module_view1, module_view2) -> "Cell":
-    """Combine two morphologies into a single cell.
+    """Combines two morphologies into a single cell.
 
     Both morphologies must have the same number of compartments per branch in all
     branches.

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -93,11 +93,19 @@ def test_distance_within_jit(SimpleCell, kind: str):
     cell[0, 0].stimulate(0.1 * jnp.ones((100,)))
     cell[0, 0].record()
 
+    if kind == "direct":
+        dists = distance_direct(cell[0, 0], cell)
+    elif kind == "pathwise":
+        dists = distance_pathwise(cell[0, 0], cell)
+    else:
+        raise ValueError
+
     def simulate(sigmoid_offset, global_scaling):
         pstate = None
+        counter = 0
         for branch in cell:
             for comp in branch:
-                dist = distance_pathwise(cell[0, 0], comp, kind=kind)[0]
+                dist = dists[counter]
                 conductance = global_scaling / (jnp.exp(-(dist + sigmoid_offset)))
                 pstate = comp.data_set("Leak_gLeak", conductance * 1e-4, pstate)
         return jx.integrate(cell, param_state=pstate)

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -9,10 +9,12 @@ jax.config.update("jax_platform_name", "cpu")
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from jax import jit
 
 import jaxley as jx
 from jaxley.channels import Leak
+from jaxley.morphology import distance
 
 
 def test_direct_distance(SimpleCell):
@@ -22,16 +24,18 @@ def test_direct_distance(SimpleCell):
     cell = SimpleCell(5, ncomp)
     cell.branch("all").loc("all").set("length", length)
     cell.compute_xyz()
-    dist = cell.branch(0).loc(0.0).distance(cell.branch(0).loc(1.0))
-    assert dist == (ncomp - 1) * length
+    cell.compute_compartment_centers()
+    dist = distance(cell.branch(0).loc(0.0), cell.branch(0).loc(1.0), kind="direct")
+    assert dist[0] == (ncomp - 1) * length
 
     comp = jx.Compartment()
     branch = jx.Branch(comp, ncomp=ncomp)
     cell = jx.Cell(branch, parents=[-1, 0, 1])
     cell.branch("all").loc("all").set("length", length)
     cell.compute_xyz()
-    dist = cell.branch(0).loc(0.0).distance(cell.branch(2).loc(1.0))
-    assert dist == (3 * ncomp - 1) * length
+    cell.compute_compartment_centers()
+    dist = distance(cell.branch(0).loc(0.0), cell.branch(2).loc(1.0), kind="direct")
+    assert dist[0] == (3 * ncomp - 1) * length
 
     move_x = 220.0
     comp = jx.Compartment()
@@ -41,23 +45,48 @@ def test_direct_distance(SimpleCell):
     net = jx.Network([cell for _ in range(2)])
     net.compute_xyz()
     net.cell(1).move(move_x, 0, 0)
-    dist = net.cell(1).branch(0).loc(0.0).distance(net.cell(0).branch(0).loc(0.0))
-    assert dist == move_x
+    net.compute_compartment_centers()
+    dist = distance(
+        net.cell(1).branch(0).loc(0.0), net.cell(0).branch(0).loc(0.0), kind="direct"
+    )
+    assert dist[0] == move_x
 
-    dist = net.cell(0).branch(0).loc(0.0).distance(net.cell(0).branch(0).loc(0.0))
-    assert dist == 0.0
+    dist = distance(
+        net.cell(0).branch(0).loc(0.0), net.cell(0).branch(0).loc(0.0), kind="direct"
+    )
+    assert dist[0] == 0.0
 
-    dist = net.cell(1).branch(2).loc(0.3).distance(net.cell(1).branch(2).loc(0.3))
-    assert dist == 0.0
+    dist = distance(
+        net.cell(1).branch(2).loc(0.3), net.cell(1).branch(2).loc(0.3), kind="direct"
+    )
+    assert dist[0] == 0.0
 
-    dist = net.cell(1).branch(0).loc(0.0).distance(net.cell(1).branch(2).loc(1.0))
-    assert dist == (3 * ncomp - 1) * length
+    dist = distance(
+        net.cell(1).branch(0).loc(0.0), net.cell(1).branch(2).loc(1.0), kind="direct"
+    )
+    assert dist[0] == (3 * ncomp - 1) * length
 
 
-def test_distance_within_jit(SimpleCell):
+def test_pathwise_distance(SimpleCell):
+    ncomp = 4
+    length = 25.0
+    cell = SimpleCell(5, ncomp)
+    cell.branch("all").loc("all").set("length", length)
+    pathdist = distance(cell[0, 0], cell)
+    cell.nodes["path_dist"] = pathdist
+
+    dist_to_tip = cell[3, 3].nodes["path_dist"].item()
+    assert (
+        dist_to_tip == (ncomp * 3 - 1) * length
+    ), f"{dist_to_tip} != {(ncomp * 3 - 1) * length}"
+
+
+@pytest.mark.parametrize("kind", ["direct", "pathwise"])
+def test_distance_within_jit(SimpleCell, kind: str):
     cell = SimpleCell(2, 3)
     cell.insert(Leak())
     cell.compute_xyz()
+    cell.compute_compartment_centers()
 
     cell[0, 0].stimulate(0.1 * jnp.ones((100,)))
     cell[0, 0].record()
@@ -66,8 +95,8 @@ def test_distance_within_jit(SimpleCell):
         pstate = None
         for branch in cell:
             for comp in branch:
-                distance = cell[0, 0].distance(comp)
-                conductance = global_scaling / (jnp.exp(-(distance + sigmoid_offset)))
+                dist = distance(cell[0, 0], comp, kind=kind)[0]
+                conductance = global_scaling / (jnp.exp(-(dist + sigmoid_offset)))
                 pstate = comp.data_set("Leak_gLeak", conductance * 1e-4, pstate)
         return jx.integrate(cell, param_state=pstate)
 

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -1,6 +1,8 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 
+import os
+
 import jax
 
 jax.config.update("jax_enable_x64", True)
@@ -14,7 +16,7 @@ from jax import jit
 
 import jaxley as jx
 from jaxley.channels import Leak
-from jaxley.morphology import distance
+from jaxley.morphology import distance_direct, distance_pathwise
 
 
 def test_direct_distance(SimpleCell):
@@ -25,7 +27,7 @@ def test_direct_distance(SimpleCell):
     cell.branch("all").loc("all").set("length", length)
     cell.compute_xyz()
     cell.compute_compartment_centers()
-    dist = distance(cell.branch(0).loc(0.0), cell.branch(0).loc(1.0), kind="direct")
+    dist = distance_direct(cell.branch(0).loc(0.0), cell.branch(0).loc(1.0))
     assert dist[0] == (ncomp - 1) * length
 
     comp = jx.Compartment()
@@ -34,7 +36,7 @@ def test_direct_distance(SimpleCell):
     cell.branch("all").loc("all").set("length", length)
     cell.compute_xyz()
     cell.compute_compartment_centers()
-    dist = distance(cell.branch(0).loc(0.0), cell.branch(2).loc(1.0), kind="direct")
+    dist = distance_direct(cell.branch(0).loc(0.0), cell.branch(2).loc(1.0))
     assert dist[0] == (3 * ncomp - 1) * length
 
     move_x = 220.0
@@ -46,23 +48,23 @@ def test_direct_distance(SimpleCell):
     net.compute_xyz()
     net.cell(1).move(move_x, 0, 0)
     net.compute_compartment_centers()
-    dist = distance(
-        net.cell(1).branch(0).loc(0.0), net.cell(0).branch(0).loc(0.0), kind="direct"
+    dist = distance_direct(
+        net.cell(1).branch(0).loc(0.0), net.cell(0).branch(0).loc(0.0)
     )
     assert dist[0] == move_x
 
-    dist = distance(
-        net.cell(0).branch(0).loc(0.0), net.cell(0).branch(0).loc(0.0), kind="direct"
+    dist = distance_direct(
+        net.cell(0).branch(0).loc(0.0), net.cell(0).branch(0).loc(0.0)
     )
     assert dist[0] == 0.0
 
-    dist = distance(
-        net.cell(1).branch(2).loc(0.3), net.cell(1).branch(2).loc(0.3), kind="direct"
+    dist = distance_direct(
+        net.cell(1).branch(2).loc(0.3), net.cell(1).branch(2).loc(0.3)
     )
     assert dist[0] == 0.0
 
-    dist = distance(
-        net.cell(1).branch(0).loc(0.0), net.cell(1).branch(2).loc(1.0), kind="direct"
+    dist = distance_direct(
+        net.cell(1).branch(0).loc(0.0), net.cell(1).branch(2).loc(1.0)
     )
     assert dist[0] == (3 * ncomp - 1) * length
 
@@ -72,7 +74,7 @@ def test_pathwise_distance(SimpleCell):
     length = 25.0
     cell = SimpleCell(5, ncomp)
     cell.branch("all").loc("all").set("length", length)
-    pathdist = distance(cell[0, 0], cell)
+    pathdist = distance_pathwise(cell[0, 0], cell)
     cell.nodes["path_dist"] = pathdist
 
     dist_to_tip = cell[3, 3].nodes["path_dist"].item()
@@ -95,7 +97,7 @@ def test_distance_within_jit(SimpleCell, kind: str):
         pstate = None
         for branch in cell:
             for comp in branch:
-                dist = distance(cell[0, 0], comp, kind=kind)[0]
+                dist = distance_pathwise(cell[0, 0], comp, kind=kind)[0]
                 conductance = global_scaling / (jnp.exp(-(dist + sigmoid_offset)))
                 pstate = comp.data_set("Leak_gLeak", conductance * 1e-4, pstate)
         return jx.integrate(cell, param_state=pstate)
@@ -106,3 +108,64 @@ def test_distance_within_jit(SimpleCell, kind: str):
     jitted_simulate = jit(simulate)
     v = jitted_simulate(sigmoid_offset, global_scaling)
     assert np.invert(np.any(np.isnan(v)))
+
+
+def test_distance_swc(SimpleMorphCell):
+    """Ensures that the distance computation for an SWC file remains unchanged."""
+    dirname = os.path.dirname(__file__)
+    fname = os.path.join(dirname, "swc_files", "morph_ca1_n120_250.swc")
+
+    cell = SimpleMorphCell(
+        fname,
+        1,
+        max_branch_len=2_000.0,
+        ignore_swc_tracing_interruptions=True,
+    )
+    cell.set("axial_resistivity", 100.0)
+    # Reasonable default values for most models.
+    frequency = 100.0
+    d_lambda = 0.1  # Larger -> more coarse-grained.
+
+    for branch in cell.branches:
+        diameter = 2 * branch.nodes["radius"].to_numpy()[0]
+        c_m = branch.nodes["capacitance"].to_numpy()[0]
+        r_a = branch.nodes["axial_resistivity"].to_numpy()[0]
+        l = branch.nodes["length"].to_numpy()[0]
+
+        lambda_f = 1e5 * np.sqrt(diameter / (4 * np.pi * frequency * c_m * r_a))
+        ncomp = int((l / (d_lambda * lambda_f) + 0.9) / 2) * 2 + 1
+        branch.set_ncomp(ncomp, initialize=False)
+
+    # After the loop, you have to run `cell.initialize()` because we passed
+    # `set_ncomp(..., initialize=False)` for speeding up the loop over branches.
+    cell.initialize()
+
+    dists_pathwise = distance_pathwise(cell.soma.branch(0).comp(0), cell)
+    dists_direct_250610 = np.asarray(
+        [
+            0.0,
+            368.06401336,
+            692.67274231,
+            864.42547931,
+            806.69255969,
+            743.73139166,
+            760.54892662,
+        ]
+    )
+    error = np.max(np.asarray(dists_pathwise)[::10] - dists_direct_250610)
+    assert error < 1e-8, f"Error for pathwise distance is to large: {error} > 1e-8."
+
+    dists_direct = distance_direct(cell.soma.branch(0).comp(0), cell)
+    dists_direct_250610 = np.asarray(
+        [
+            0.0,
+            194.3651027,
+            383.63095437,
+            467.20607951,
+            483.88675182,
+            413.21848932,
+            428.11599931,
+        ]
+    )
+    error = np.max(np.asarray(dists_direct)[::10] - dists_direct_250610)
+    assert error < 1e-8, f"Error for direct distance is to large: {error} > 1e-8."


### PR DESCRIPTION
Closes #572 

- deprecate `module.distance()`. It is replaced by `jx.morphology.distance_direct()`
- introduce `jx.morphology.distance_pathwise()`
- the new `distance_pathwise()` allows users to compute pathwise distance.

### Examples

Example 1: The following computes the pathwise distance between the zero-eth soma compartment and all other compartments. It then saves this distance in
`cell.nodes["path_dist_from_soma"]`.
```python
from jaxley.morphology import distance_pathwise

path_dists = distance_pathwise(cell.soma.branch(0).comp(0), cell)
cell.nodes["path_dist_from_soma"] = path_dists
```

Example 2: The following computes the pathwise distance between two compartments.
```python
from jaxley.morphology import distance_pathwise

dist = distance_pathwise(cell.branch(8).comp(2), cell.branch(2).comp(0))
```

Example 3: The following computes the direct (line of sight) distance between the zero-eth soma compartment and all other compartments. It then saves this distance in `cell.nodes["direct_dist_from_soma"]`.

```python
from jaxley.morphology import distance_direct

cell.compute_compartment_centers()  # necessary if you modified branch length.
direct_dists = distance_direct(cell.soma.branch(0).comp(0), cell)
cell.nodes["direct_dist_from_soma"] = direct_dists
```