### PR TITLE
Bugfix for solver speed for networks on GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # 0.11.2 (pre-release)
 
+### 🐛 Bug fixes
+
+- Bugfix for `Network`s on `GPU`: since `v0.9.0`, networks had been very slow on GPU
+because the voltage equations of cells had been processed in sequence, not in parallel.
+This is now solved, giving a large speed-up for networks consisting of many cells (#691,
+@michaeldeistler, thanks to @VENOM314 for reporting)
+
 ### 📚 Documentation
 
-- Remove all content from the old documentation website (#689, @michaeldeistler)
+- Remove all content from the old mkdocs documentation website (#689, @michaeldeistler)
 
 
 # 0.11.1

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -988,7 +988,6 @@ class Module(ABC):
         else:
             self._solver_device = "cpu" if allowed_nodes_per_level == 1 else "gpu"
 
-
         if np.any(np.isnan(self.xyzr[0][:, :3])):
             self.compute_xyz()
             self.compute_compartment_centers()

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -948,7 +948,7 @@ class Module(ABC):
         self._indptr_jax_spsolve = indptr
 
     def _init_solver_jaxley_dhs_solve(
-        self, allowed_nodes_per_level: Optional[int] = 1, root: int = 0
+        self, allowed_nodes_per_level: Optional[int] = None, root: int = 0
     ) -> None:
         """Create module attributes for indexing with the `jaxley.dhs` voltage volver.
 
@@ -962,7 +962,9 @@ class Module(ABC):
         Args:
             allowed_nodes_per_level: How many nodes are visited before the level is
                 increased, even if the number of hops did not change. This sets the
-                amount of parallelism of the simulation.
+                amount of parallelism of the simulation. Setting this value to 1
+                automatically sets `self._solver_device` to `cpu`, and setting it to
+                values larger than 1 automatically sets `self._solver_device` to `gpu`.
             root: The root node from which to start tracing.
         """
         # Infer the amount of parallelism of the solver. Note that the `jaxley.dhs.cpu`
@@ -983,6 +985,9 @@ class Module(ABC):
                 allowed_nodes_per_level = 1
             else:
                 allowed_nodes_per_level = 32
+        else:
+            self._solver_device = "cpu" if allowed_nodes_per_level == 1 else "gpu"
+
 
         if np.any(np.isnan(self.xyzr[0][:, :3])):
             self.compute_xyz()

--- a/jaxley/modules/compartment.py
+++ b/jaxley/modules/compartment.py
@@ -37,6 +37,7 @@ class Compartment(Module):
     compartment_states: Dict = {"v": -70.0}
 
     def __init__(self):
+        """Initialize a compartment."""
         super().__init__()
 
         self.ncomp = 1

--- a/jaxley/utils/solver_utils.py
+++ b/jaxley/utils/solver_utils.py
@@ -226,8 +226,6 @@ def dhs_group_comps_into_levels(new_node_order: np.ndarray) -> List[np.ndarray]:
     Args:
         new_node_order: Array of shape (N, 3). The `3` are (node, parent, level).
             `N` is the number of compartment edges to be processed.
-        allowed_nodes_per_level: The maximal number of compartments in each level.
-            No `level` can exist more often than `allowed_nodes_per_level`.
 
     Returns:
         Array of shape (num_levels, allowed_nodes_per_level, 2), where 2 indicates

--- a/mkdocs/README.md
+++ b/mkdocs/README.md
@@ -1,6 +1,10 @@
 # Documentation
 
-The documentation is available at: <https://jaxleyverse.github.io/jaxley/>
+This folder used to host the _outdated_ mkdocs documentation, which was available at:
+<https://jaxleyverse.github.io/jaxley/>.
+
+This folder now only exists to maintain a minimal `mkdocs` website. You should not
+be changing anything here, unless you are confident in what you are doing.
 
 ## Building the Documentation
 

--- a/tests/jaxley_identical/test_basic_modules.py
+++ b/tests/jaxley_identical/test_basic_modules.py
@@ -368,7 +368,11 @@ def test_complex_net(voltage_solver, SimpleCell):
         # On CPU we have to run this manually. On GPU, it gets run automatically with
         # allowed_nodes_per_level=32.
         cell._init_solver_jaxley_dhs_solve(allowed_nodes_per_level=4)
-    net = jx.Network([cell for _ in range(7)])
+
+    if voltage_solver == "jaxley.dhs.cpu":
+        net = jx.Network([cell for _ in range(7)], vectorize_cells=False)
+    else:
+        net = jx.Network([cell for _ in range(7)], vectorize_cells=True)
 
     net.insert(HH())
 

--- a/tests/jaxley_identical/test_swc.py
+++ b/tests/jaxley_identical/test_swc.py
@@ -114,7 +114,11 @@ def test_swc_net(voltage_solver: str, morph: str, SimpleMorphCell):
         cell1._init_solver_jaxley_dhs_solve(allowed_nodes_per_level=4)
         cell2._init_solver_jaxley_dhs_solve(allowed_nodes_per_level=4)
 
-    network = jx.Network([cell1, cell2])
+    if voltage_solver == "jaxley.dhs.gpu":
+        network = jx.Network([cell1, cell2], vectorize_cells=True)
+    else:
+        network = jx.Network([cell1, cell2], vectorize_cells=False)
+
     connect(
         network.cell(0).soma.branch(0).loc(1.0),
         network.cell(1).soma.branch(0).loc(1.0),


### PR DESCRIPTION
Only for networks of multicompartment neurons (not point neurons), and only on GPU, our solver has been extremely suboptimal since `Jaxley` version `0.9.0`, following [this PR](https://github.com/jaxleyverse/jaxley/pull/625).

This is due to a bug which caused the voltages of cells to be processed sequentially, instead of in parallel (If they are multicompartment). This PR provides a minimal fix for this.

### API changes

There are no breaking changes for the API. However, this PR introduces a new keyword argument to the `Network`:
```python
net = jx.Network([cell], vectorize_cells=True)
```
When set to `True`, we automatically use the gpu-based solver and we parallelize across cells. This is the default on GPU. The default on CPU is `False` because it optimizes compile time (and barely affects runtime on CPU).

### Customization

To run the GPU solver _for networks_ on CPU, you have to do:
```python
cell._init_solver_jaxley_dhs_solve(allowed_nodes_per_level=16)
net = jx.Network([cell], vectorize_cells=True)
v = jx.integrate(net)
```

To run the CPU solver _for networks_ on GPU, do:
```python
cell._init_solver_jaxley_dhs_solve(allowed_nodes_per_level=1)
net = jx.Network([cell], vectorize_cells=False)
v = jx.integrate(net)
```