### PR TITLE
Follow Jax Typing Practices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.11.3 (pre-release)
+
+### 🛠️ Internal updates
+
+-  follow jax typing practices with Array and ArrayLike (#693, @alexpejovic)
+
+
 # 0.11.2 (pre-release)
 
 ### 📚 Documentation

--- a/jaxley/channels/channel.py
+++ b/jaxley/channels/channel.py
@@ -82,9 +82,7 @@ class Channel:
         }
         return self
 
-    def update_states(
-        self, states, dt, v, params
-    ) -> tuple[Array, tuple[Array, Array]]:
+    def update_states(self, states, dt, v, params) -> tuple[Array, tuple[Array, Array]]:
         """Return the updated states."""
         raise NotImplementedError
 

--- a/jaxley/channels/channel.py
+++ b/jaxley/channels/channel.py
@@ -5,7 +5,8 @@ from abc import ABC, abstractmethod
 from typing import Dict, Optional, Tuple
 from warnings import warn
 
-import jax.numpy as jnp
+from jax import Array
+from jax.typing import ArrayLike
 
 
 class Channel:
@@ -83,12 +84,12 @@ class Channel:
 
     def update_states(
         self, states, dt, v, params
-    ) -> Tuple[jnp.ndarray, Tuple[jnp.ndarray, jnp.ndarray]]:
+    ) -> tuple[Array, tuple[Array, Array]]:
         """Return the updated states."""
         raise NotImplementedError
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v: float, params: dict[str, ArrayLike]
     ):
         """Given channel states and voltage, return the current through the channel.
 
@@ -104,9 +105,9 @@ class Channel:
 
     def init_state(
         self,
-        states: Dict[str, jnp.ndarray],
-        v: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
+        v: ArrayLike,
+        params: dict[str, ArrayLike],
         delta_t: float,
     ):
         """Initialize states of channel."""

--- a/jaxley/channels/channel.py
+++ b/jaxley/channels/channel.py
@@ -1,6 +1,5 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Tuple
 from warnings import warn
@@ -87,7 +86,7 @@ class Channel:
         raise NotImplementedError
 
     def compute_current(
-        self, states: dict[str, ArrayLike], v: float, params: dict[str, ArrayLike]
+        self, states: dict[str, Array], v: float, params: dict[str, Array]
     ):
         """Given channel states and voltage, return the current through the channel.
 

--- a/jaxley/channels/hh.py
+++ b/jaxley/channels/hh.py
@@ -35,10 +35,10 @@ class HH(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt: float,
         v: float,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ) -> dict[str, Array]:
         """Return updated HH channel state."""
         prefix = self._name
@@ -49,7 +49,7 @@ class HH(Channel):
         return {f"{prefix}_m": new_m, f"{prefix}_h": new_h, f"{prefix}_n": new_n}
 
     def compute_current(
-        self, states: dict[str, ArrayLike], v: float, params: dict[str, ArrayLike]
+        self, states: dict[str, Array], v: float, params: dict[str, Array]
     ) -> float:
         """Return current through HH channels."""
         prefix = self._name

--- a/jaxley/channels/hh.py
+++ b/jaxley/channels/hh.py
@@ -1,9 +1,10 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Dict, Optional
+from typing import Optional
 
 import jax.numpy as jnp
+from jax import Array
+from jax.typing import ArrayLike
 
 from jaxley.channels import Channel
 from jaxley.solver_gate import save_exp, solve_gate_exponential
@@ -34,11 +35,11 @@ class HH(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
-        dt,
-        v,
-        params: Dict[str, jnp.ndarray],
-    ):
+        states: dict[str, ArrayLike],
+        dt: float,
+        v: float,
+        params: dict[str, ArrayLike],
+    ) -> dict[str, Array]:
         """Return updated HH channel state."""
         prefix = self._name
         m, h, n = states[f"{prefix}_m"], states[f"{prefix}_h"], states[f"{prefix}_n"]
@@ -48,8 +49,8 @@ class HH(Channel):
         return {f"{prefix}_m": new_m, f"{prefix}_h": new_h, f"{prefix}_n": new_n}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
-    ):
+        self, states: dict[str, ArrayLike], v: float, params: dict[str, ArrayLike]
+    ) -> float:
         """Return current through HH channels."""
         prefix = self._name
         m, h, n = states[f"{prefix}_m"], states[f"{prefix}_h"], states[f"{prefix}_n"]
@@ -64,7 +65,13 @@ class HH(Channel):
             + gLeak * (v - params[f"{prefix}_eLeak"])
         )
 
-    def init_state(self, states, v, params, delta_t):
+    def init_state(
+        self,
+        states: dict[str, ArrayLike],
+        v: ArrayLike,
+        params: dict[str, ArrayLike],
+        delta_t: float,
+    ) -> dict[str, float]:
         """Initialize the state such at fixed point of gate dynamics."""
         prefix = self._name
         alpha_m, beta_m = self.m_gate(v)

--- a/jaxley/channels/pospischil.py
+++ b/jaxley/channels/pospischil.py
@@ -2,6 +2,7 @@
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
 
+from jax import Array
 from jax.typing import ArrayLike
 
 from jaxley.channels import Channel
@@ -48,17 +49,15 @@ class Leak(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """No state to update."""
         return {}
 
-    def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
-    ):
+    def compute_current(self, states: dict[str, Array], v, params: dict[str, Array]):
         """Return current."""
         prefix = self._name
         gLeak = params[f"{prefix}_gLeak"]  # S/cm^2
@@ -86,10 +85,10 @@ class Na(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update state."""
         prefix = self._name
@@ -98,9 +97,7 @@ class Na(Channel):
         new_h = solve_gate_exponential(h, dt, *self.h_gate(v, params["vt"]))
         return {f"{prefix}_m": new_m, f"{prefix}_h": new_h}
 
-    def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
-    ):
+    def compute_current(self, states: dict[str, Array], v, params: dict[str, Array]):
         """Return current."""
         prefix = self._name
         m, h = states[f"{prefix}_m"], states[f"{prefix}_h"]
@@ -157,10 +154,10 @@ class K(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update state."""
         prefix = self._name
@@ -168,9 +165,7 @@ class K(Channel):
         new_n = solve_gate_exponential(n, dt, *self.n_gate(v, params["vt"]))
         return {f"{prefix}_n": new_n}
 
-    def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
-    ):
+    def compute_current(self, states: dict[str, Array], v, params: dict[str, Array]):
         """Return current."""
         prefix = self._name
         n = states[f"{prefix}_n"]
@@ -213,10 +208,10 @@ class Km(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update state."""
         prefix = self._name
@@ -226,9 +221,7 @@ class Km(Channel):
         )
         return {f"{prefix}_p": new_p}
 
-    def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
-    ):
+    def compute_current(self, states: dict[str, Array], v, params: dict[str, Array]):
         """Return current."""
         prefix = self._name
         p = states[f"{prefix}_p"]
@@ -269,10 +262,10 @@ class CaL(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update state."""
         prefix = self._name
@@ -281,9 +274,7 @@ class CaL(Channel):
         new_r = solve_gate_exponential(r, dt, *self.r_gate(v))
         return {f"{prefix}_q": new_q, f"{prefix}_r": new_r}
 
-    def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
-    ):
+    def compute_current(self, states: dict[str, Array], v, params: dict[str, Array]):
         """Return current."""
         prefix = self._name
         q, r = states[f"{prefix}_q"], states[f"{prefix}_r"]
@@ -338,10 +329,10 @@ class CaT(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update state."""
         prefix = self._name
@@ -351,9 +342,7 @@ class CaT(Channel):
         )
         return {f"{prefix}_u": new_u}
 
-    def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
-    ):
+    def compute_current(self, states: dict[str, Array], v, params: dict[str, Array]):
         """Return current."""
         prefix = self._name
         u = states[f"{prefix}_u"]

--- a/jaxley/channels/pospischil.py
+++ b/jaxley/channels/pospischil.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
+
 from jax.typing import ArrayLike
 
 from jaxley.channels import Channel

--- a/jaxley/channels/pospischil.py
+++ b/jaxley/channels/pospischil.py
@@ -1,9 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Dict, Optional
-
-import jax.numpy as jnp
+from typing import Optional
+from jax.typing import ArrayLike
 
 from jaxley.channels import Channel
 from jaxley.solver_gate import (
@@ -49,16 +47,16 @@ class Leak(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """No state to update."""
         return {}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
     ):
         """Return current."""
         prefix = self._name
@@ -87,10 +85,10 @@ class Na(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update state."""
         prefix = self._name
@@ -100,7 +98,7 @@ class Na(Channel):
         return {f"{prefix}_m": new_m, f"{prefix}_h": new_h}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
     ):
         """Return current."""
         prefix = self._name
@@ -158,10 +156,10 @@ class K(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update state."""
         prefix = self._name
@@ -170,7 +168,7 @@ class K(Channel):
         return {f"{prefix}_n": new_n}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
     ):
         """Return current."""
         prefix = self._name
@@ -214,10 +212,10 @@ class Km(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update state."""
         prefix = self._name
@@ -228,7 +226,7 @@ class Km(Channel):
         return {f"{prefix}_p": new_p}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
     ):
         """Return current."""
         prefix = self._name
@@ -270,10 +268,10 @@ class CaL(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update state."""
         prefix = self._name
@@ -283,7 +281,7 @@ class CaL(Channel):
         return {f"{prefix}_q": new_q, f"{prefix}_r": new_r}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
     ):
         """Return current."""
         prefix = self._name
@@ -339,10 +337,10 @@ class CaT(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update state."""
         prefix = self._name
@@ -353,7 +351,7 @@ class CaT(Channel):
         return {f"{prefix}_u": new_u}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
     ):
         """Return current."""
         prefix = self._name

--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -101,7 +101,7 @@ def build_init_and_step_fn(
     external_inds = module.external_inds.copy()
 
     def init_fn(
-        params: list[dict[str, ArrayLike]],
+        params: list[dict[str, Array]],
         all_states: dict | None = None,
         param_state: list[dict] | None = None,
         delta_t: float = 0.025,
@@ -227,7 +227,7 @@ def add_clamps(
 
 def integrate(
     module: Module,
-    params: list[dict[str, ArrayLike]] = [],
+    params: list[dict[str, Array]] = [],
     *,
     param_state: list[dict] | None = None,
     data_stimuli: tuple[ArrayLike, pd.DataFrame] | None = None,

--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -1,12 +1,14 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
+from collections.abc import Callable
 from math import prod
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 import pandas as pd
+from jax import Array
+from jax.typing import ArrayLike
 
 from jaxley.modules import Module
 from jaxley.utils.cell_utils import params_to_pstate
@@ -99,9 +101,9 @@ def build_init_and_step_fn(
     external_inds = module.external_inds.copy()
 
     def init_fn(
-        params: List[Dict[str, jnp.ndarray]],
-        all_states: Optional[Dict] = None,
-        param_state: Optional[List[Dict]] = None,
+        params: list[dict[str, ArrayLike]],
+        all_states: dict | None = None,
+        param_state: list[dict] | None = None,
         delta_t: float = 0.025,
     ) -> Tuple[Dict, Dict]:
         """Initializes the parameters and states of the neuron model.
@@ -164,10 +166,10 @@ def build_init_and_step_fn(
 
 
 def add_stimuli(
-    externals: Dict,
-    external_inds: Dict,
-    data_stimuli: Optional[Tuple[jnp.ndarray, pd.DataFrame]] = None,
-) -> Tuple[Dict, Dict]:
+    externals: dict,
+    external_inds: dict,
+    data_stimuli: tuple[ArrayLike, pd.DataFrame] | None = None,
+) -> tuple[dict, dict]:
     """Extends the external inputs with the stimuli.
 
     Args:
@@ -194,10 +196,10 @@ def add_stimuli(
 
 
 def add_clamps(
-    externals: Dict,
-    external_inds: Dict,
-    data_clamps: Optional[Tuple[str, jnp.ndarray, pd.DataFrame]] = None,
-) -> Tuple[Dict, Dict]:
+    externals: dict,
+    external_inds: dict,
+    data_clamps: tuple[str, ArrayLike, pd.DataFrame] | None = None,
+) -> tuple[dict, dict]:
     """Adds clamps to the external inputs.
 
     Args:
@@ -225,21 +227,20 @@ def add_clamps(
 
 def integrate(
     module: Module,
-    params: List[Dict[str, jnp.ndarray]] = [],
+    params: list[dict[str, ArrayLike]] = [],
     *,
-    param_state: Optional[List[Dict]] = None,
-    data_stimuli: Optional[Tuple[jnp.ndarray, pd.DataFrame]] = None,
-    data_clamps: Optional[Tuple[str, jnp.ndarray, pd.DataFrame]] = None,
-    t_max: Optional[float] = None,
+    param_state: list[dict] | None = None,
+    data_stimuli: tuple[ArrayLike, pd.DataFrame] | None = None,
+    data_clamps: tuple[str, ArrayLike, pd.DataFrame] | None = None,
+    t_max: float | None = None,
     delta_t: float = 0.025,
     solver: str = "bwd_euler",
     voltage_solver: str = "jaxley.dhs",
     checkpoint_lengths: Optional[List[int]] = None,
     all_states: Optional[Dict] = None,
     return_states: bool = False,
-) -> jnp.ndarray:
-    """
-    Solves ODE and simulates neuron model.
+) -> Array:
+    """Solves ODE and simulates neuron model.
 
     Args:
         params: Trainable parameters returned by `get_parameters()`.

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -13,8 +13,9 @@ import jax.numpy as jnp
 import networkx as nx
 import numpy as np
 import pandas as pd
-from jax import jit, vmap
+from jax import Array, vmap
 from jax.lax import ScatterDimensionNumbers, scatter_add
+from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 
 from jaxley.channels import Channel
@@ -159,7 +160,7 @@ class Module(ABC):
 
         self._cumsum_nbranches: Optional[np.ndarray] = None
 
-        self.comb_parents: jnp.ndarray = jnp.asarray([-1])
+        self.comb_parents: ArrayLike = jnp.asarray([-1])
 
         self.initialized_solver: bool = False
         self.initialized_syns: bool = False
@@ -183,8 +184,8 @@ class Module(ABC):
         self.diffusion_states: List[str] = []
 
         # For trainable parameters.
-        self.indices_set_by_trainables: List[jnp.ndarray] = []
-        self.trainable_params: List[Dict[str, jnp.ndarray]] = []
+        self.indices_set_by_trainables: list[ArrayLike] = []
+        self.trainable_params: list[dict[str, ArrayLike]] = []
         self.allow_make_trainable: bool = True
         self.num_trainable_params: int = 0
 
@@ -194,9 +195,9 @@ class Module(ABC):
         # For stimuli or clamps.
         # E.g. `self.externals = {"v": zeros(1000,2), "i": ones(1000, 2)}`
         # for 1000 timesteps and two compartments.
-        self.externals: Dict[str, jnp.ndarray] = {}
+        self.externals: dict[str, ArrayLike] = {}
         # E.g. `self.external)inds = {"v": jnp.asarray([0,1]), "i": jnp.asarray([2,3])}`
-        self.external_inds: Dict[str, jnp.ndarray] = {}
+        self.external_inds: dict[str, ArrayLike] = {}
 
         # x, y, z coordinates and radius.
         self.xyzr: List[np.ndarray] = []
@@ -1057,7 +1058,7 @@ class Module(ABC):
             parents[nodes[:, 0]] = nodes[:, 1]
         self._dhs_solve_indexer["parent_lookup"] = parents.astype(int)
 
-    def set(self, key: str, val: Union[float, jnp.ndarray]):
+    def set(self, key: str, val: float | ArrayLike):
         """Set parameter of module (or its view) to a new value.
 
         Note that this function can not be called within `jax.jit` or `jax.grad`.
@@ -1067,7 +1068,7 @@ class Module(ABC):
 
         Args:
             key: The name of the parameter to set.
-            val: The value to set the parameter to. If it is `jnp.ndarray` then it
+            val: The value to set the parameter to. If it is `ArrayLike` then it
                 must be of shape `(len(num_compartments))`.
         """
         if key in [f"axial_diffusion_{ion_name}" for ion_name in self.diffusion_states]:
@@ -1122,14 +1123,14 @@ class Module(ABC):
     def data_set(
         self,
         key: str,
-        val: Union[float, jnp.ndarray],
-        param_state: Optional[List[Dict]],
+        val: float | ArrayLike,
+        param_state: list[dict] | None,
     ):
         """Set parameter of module (or its view) to a new value within `jit`.
 
         Args:
             key: The name of the parameter to set.
-            val: The value to set the parameter to. If it is `jnp.ndarray` then it
+            val: The value to set the parameter to. If it is `ArrayLike` then it
                 must be of shape `(len(num_compartments))`.
             param_state: State of the set parameters, internally used such that this
                 function does not modify global state.
@@ -1471,7 +1472,7 @@ class Module(ABC):
                 f"parameters: {self.base.num_trainable_params}"
             )
 
-    def write_trainables(self, trainable_params: List[Dict[str, jnp.ndarray]]):
+    def write_trainables(self, trainable_params: list[dict[str, ArrayLike]]):
         """Write the trainables into `.nodes` and `.edges`.
 
         This allows to, e.g., visualize trained networks with `.vis()`.
@@ -1598,7 +1599,7 @@ class Module(ABC):
             synapse_states + self.synapse_current_names,
         )
 
-    def get_parameters(self) -> List[Dict[str, jnp.ndarray]]:
+    def get_parameters(self) -> list[dict[str, Array]]:
         """Get all trainable parameters.
 
         The returned parameters should be passed to
@@ -1611,7 +1612,7 @@ class Module(ABC):
         return self.trainable_params
 
     @only_allow_module
-    def get_all_parameters(self, pstate: List[Dict]) -> Dict[str, jnp.ndarray]:
+    def get_all_parameters(self, pstate: list[dict]) -> dict[str, Array]:
         # TODO FROM #447: MAKE THIS WORK FOR VIEW?
         """Return all parameters (and coupling conductances) needed to simulate.
 
@@ -1715,7 +1716,7 @@ class Module(ABC):
         return params
 
     @only_allow_module
-    def _get_states_from_nodes_and_edges(self) -> Dict[str, jnp.ndarray]:
+    def _get_states_from_nodes_and_edges(self) -> dict[str, Array]:
         """Return states as they are set in the `.nodes` and `.edges` tables.
 
         TODO FROM #447: MAKE THIS WORK FOR VIEW?
@@ -1733,8 +1734,8 @@ class Module(ABC):
 
     @only_allow_module
     def get_all_states(
-        self, pstate: List[Dict], all_params, delta_t: float
-    ) -> Dict[str, jnp.ndarray]:
+        self, pstate: list[dict], all_params, delta_t: float
+    ) -> dict[str, Array]:
         # TODO FROM #447: MAKE THIS WORK FOR VIEW?
         """Get the full initial state of the module from jaxnodes and trainables.
 
@@ -1971,7 +1972,7 @@ class Module(ABC):
         else:
             self.base.recordings = pd.DataFrame().from_dict({})
 
-    def stimulate(self, current: Optional[jnp.ndarray] = None, verbose: bool = True):
+    def stimulate(self, current: ArrayLike | None = None, verbose: bool = True):
         """Insert a stimulus into the compartment.
 
         current must be a 1d array or have batch dimension of size `(num_compartments, )`
@@ -1987,7 +1988,7 @@ class Module(ABC):
         """
         self._external_input("i", current, verbose=verbose)
 
-    def clamp(self, state_name: str, state_array: jnp.ndarray, verbose: bool = True):
+    def clamp(self, state_name: str, state_array: ArrayLike, verbose: bool = True):
         """Clamp a state to a given value across specified compartments.
 
         Args:
@@ -2002,7 +2003,7 @@ class Module(ABC):
     def _external_input(
         self,
         key: str,
-        values: Optional[jnp.ndarray],
+        values: ArrayLike | None,
         verbose: bool = True,
     ):
         comp_states, edge_states = self._get_state_names()
@@ -2041,10 +2042,10 @@ class Module(ABC):
 
     def data_stimulate(
         self,
-        current: jnp.ndarray,
-        data_stimuli: Optional[Tuple[jnp.ndarray, pd.DataFrame]] = None,
+        current: ArrayLike,
+        data_stimuli: tuple[ArrayLike, pd.DataFrame] | None = None,
         verbose: bool = False,
-    ) -> Tuple[jnp.ndarray, pd.DataFrame]:
+    ) -> tuple[Array, pd.DataFrame]:
         """Insert a stimulus into the module within jit (or grad).
 
         Args:
@@ -2059,8 +2060,8 @@ class Module(ABC):
     def data_clamp(
         self,
         state_name: str,
-        state_array: jnp.ndarray,
-        data_clamps: Optional[Tuple[jnp.ndarray, pd.DataFrame]] = None,
+        state_array: ArrayLike,
+        data_clamps: tuple[ArrayLike, pd.DataFrame] | None = None,
         verbose: bool = False,
     ):
         """Insert a clamp into the module within jit (or grad).
@@ -2084,8 +2085,8 @@ class Module(ABC):
     def _data_external_input(
         self,
         state_name: str,
-        state_array: jnp.ndarray,
-        data_external_input: Optional[Tuple[jnp.ndarray, pd.DataFrame]],
+        state_array: ArrayLike,
+        data_external_input: tuple[ArrayLike, pd.DataFrame] | None,
         view: pd.DataFrame,
         verbose: bool = False,
     ):
@@ -2269,14 +2270,14 @@ class Module(ABC):
     @only_allow_module
     def step(
         self,
-        u: Dict[str, jnp.ndarray],
+        u: dict[str, ArrayLike],
         delta_t: float,
-        external_inds: Dict[str, jnp.ndarray],
-        externals: Dict[str, jnp.ndarray],
-        params: Dict[str, jnp.ndarray],
+        external_inds: dict[str, ArrayLike],
+        externals: dict[str, ArrayLike],
+        params: dict[str, ArrayLike],
         solver: str = "bwd_euler",
         voltage_solver: str = "jaxley.stone",
-    ) -> Dict[str, jnp.ndarray]:
+    ) -> dict[str, Array]:
         """One step of solving the Ordinary Differential Equation.
 
         This function is called inside of `integrate` and increments the state of the
@@ -2506,12 +2507,12 @@ class Module(ABC):
 
     def _step_channels(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         delta_t: float,
         channels: List[Channel],
         channel_nodes: pd.DataFrame,
-        params: Dict[str, jnp.ndarray],
-    ) -> Tuple[Dict[str, jnp.ndarray], Tuple[jnp.ndarray, jnp.ndarray]]:
+        params: dict[str, ArrayLike],
+    ) -> tuple[dict[str, Array], tuple[Array, Array]]:
         """One step of integration of the channels and of computing their current."""
         states = self._step_channels_state(
             states, delta_t, channels, channel_nodes, params
@@ -2527,8 +2528,8 @@ class Module(ABC):
         delta_t,
         channels: List[Channel],
         channel_nodes: pd.DataFrame,
-        params: Dict[str, jnp.ndarray],
-    ) -> Dict[str, jnp.ndarray]:
+        params: dict[str, ArrayLike],
+    ) -> dict[str, Array]:
         """One integration step of the channels."""
         voltages = states["v"]
 
@@ -2565,12 +2566,12 @@ class Module(ABC):
 
     def _channel_currents(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         delta_t: float,
         channels: List[Channel],
         channel_nodes: pd.DataFrame,
-        params: Dict[str, jnp.ndarray],
-    ) -> Tuple[Dict[str, jnp.ndarray], Tuple[jnp.ndarray, jnp.ndarray]]:
+        params: dict[str, ArrayLike],
+    ) -> tuple[dict[str, Array], tuple[Array, Array]]:
         """Return the current through each channel.
 
         This is also updates `state` because the `state` also contains the current.
@@ -2629,12 +2630,12 @@ class Module(ABC):
 
     def _channel_current_components(
         self,
-        modified_state: jnp.ndarray,
-        states: Dict[str, jnp.ndarray],
+        modified_state: ArrayLike,
+        states: dict[str, ArrayLike],
         delta_t: float,
         channel: Channel,
         indices: pd.DataFrame,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Computes current through a channel and its linear and const components.
 
@@ -2671,12 +2672,12 @@ class Module(ABC):
 
     def _step_synapse(
         self,
-        u: Dict[str, jnp.ndarray],
-        syn_channels: List[Channel],
-        params: Dict[str, jnp.ndarray],
+        u: dict[str, ArrayLike],
+        syn_channels: list[Channel],
+        params: dict[str, ArrayLike],
         delta_t: float,
         edges: pd.DataFrame,
-    ) -> Tuple[Dict[str, jnp.ndarray], Tuple[jnp.ndarray, jnp.ndarray]]:
+    ) -> tuple[dict[str, Array], tuple[Array, Array]]:
         """One step of integration of the channels.
 
         `Network` overrides this method (because it actually has synapses), whereas
@@ -2692,18 +2693,17 @@ class Module(ABC):
         params,
         delta_t,
         edges: pd.DataFrame,
-    ) -> Tuple[Dict[str, jnp.ndarray], Tuple[jnp.ndarray, jnp.ndarray]]:
+    ) -> tuple[dict[str, Array], tuple[Array, Array]]:
         return states, (None, None)
 
     @staticmethod
     def _get_external_input(
-        voltages: jnp.ndarray,
-        i_inds: jnp.ndarray,
-        i_stim: jnp.ndarray,
+        voltages: ArrayLike,
+        i_inds: ArrayLike,
+        i_stim: ArrayLike,
         area: float,
-    ) -> jnp.ndarray:
-        """
-        Return external input to each compartment in uA / cm^2.
+    ) -> Array:
+        """Return external input to each compartment in uA / cm^2.
 
         Args:
             voltages: mV.

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -185,7 +185,7 @@ class Module(ABC):
 
         # For trainable parameters.
         self.indices_set_by_trainables: list[ArrayLike] = []
-        self.trainable_params: list[dict[str, ArrayLike]] = []
+        self.trainable_params: list[dict[str, Array]] = []
         self.allow_make_trainable: bool = True
         self.num_trainable_params: int = 0
 
@@ -1472,7 +1472,7 @@ class Module(ABC):
                 f"parameters: {self.base.num_trainable_params}"
             )
 
-    def write_trainables(self, trainable_params: list[dict[str, ArrayLike]]):
+    def write_trainables(self, trainable_params: list[dict[str, Array]]):
         """Write the trainables into `.nodes` and `.edges`.
 
         This allows to, e.g., visualize trained networks with `.vis()`.
@@ -2274,7 +2274,7 @@ class Module(ABC):
         delta_t: float,
         external_inds: dict[str, ArrayLike],
         externals: dict[str, ArrayLike],
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
         solver: str = "bwd_euler",
         voltage_solver: str = "jaxley.stone",
     ) -> dict[str, Array]:
@@ -2507,11 +2507,11 @@ class Module(ABC):
 
     def _step_channels(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         delta_t: float,
         channels: List[Channel],
         channel_nodes: pd.DataFrame,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ) -> tuple[dict[str, Array], tuple[Array, Array]]:
         """One step of integration of the channels and of computing their current."""
         states = self._step_channels_state(
@@ -2528,7 +2528,7 @@ class Module(ABC):
         delta_t,
         channels: List[Channel],
         channel_nodes: pd.DataFrame,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ) -> dict[str, Array]:
         """One integration step of the channels."""
         voltages = states["v"]
@@ -2566,11 +2566,11 @@ class Module(ABC):
 
     def _channel_currents(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         delta_t: float,
         channels: List[Channel],
         channel_nodes: pd.DataFrame,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ) -> tuple[dict[str, Array], tuple[Array, Array]]:
         """Return the current through each channel.
 
@@ -2630,12 +2630,12 @@ class Module(ABC):
 
     def _channel_current_components(
         self,
-        modified_state: ArrayLike,
-        states: dict[str, ArrayLike],
+        modified_state: Array,
+        states: dict[str, Array],
         delta_t: float,
         channel: Channel,
         indices: pd.DataFrame,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Computes current through a channel and its linear and const components.
 
@@ -2672,9 +2672,9 @@ class Module(ABC):
 
     def _step_synapse(
         self,
-        u: dict[str, ArrayLike],
+        u: dict[str, Array],
         syn_channels: list[Channel],
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
         delta_t: float,
         edges: pd.DataFrame,
     ) -> tuple[dict[str, Array], tuple[Array, Array]]:

--- a/jaxley/modules/network.py
+++ b/jaxley/modules/network.py
@@ -1,6 +1,5 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
 import itertools
 from copy import deepcopy
 from typing import Dict, List, Optional, Tuple, Union
@@ -9,7 +8,7 @@ from warnings import warn
 import jax.numpy as jnp
 import numpy as np
 import pandas as pd
-from jax import vmap
+from jax import Array, vmap
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 
@@ -239,7 +238,7 @@ class Network(Module):
         params: Dict,
         delta_t: float,
         edges: pd.DataFrame,
-    ) -> Tuple[Dict, Tuple[jnp.ndarray, jnp.ndarray]]:
+    ) -> tuple[dict, tuple[Array, Array]]:
         """Perform one step of the synapses and obtain their currents."""
         states = self._step_synapse_state(states, syn_channels, params, delta_t, edges)
         states, current_terms = self._synapse_currents(
@@ -301,7 +300,7 @@ class Network(Module):
         params: Dict,
         delta_t: float,
         edges: pd.DataFrame,
-    ) -> Tuple[Dict, Tuple[jnp.ndarray, jnp.ndarray]]:
+    ) -> tuple[dict, tuple[Array, Array]]:
         voltages = states["v"]
 
         grouped_syns = edges.groupby("type", sort=False, group_keys=False)
@@ -368,7 +367,7 @@ class Network(Module):
             syn_constant_terms -= gathered_syn_currents[1]
 
             # Add the synaptic currents through every compartment as state.
-            # `post_syn_currents` is a `jnp.ndarray` of as many elements as there are
+            # `post_syn_currents` is a `ArrayLike` of as many elements as there are
             # compartments in the network.
             # `[0]` because we only use the non-perturbed voltage.
             states[f"i_{synapse_type._name}"] = synapse_currents[0]

--- a/jaxley/optimize/optimizer.py
+++ b/jaxley/optimize/optimizer.py
@@ -14,7 +14,7 @@ class TypeOptimizer:
         self,
         optimizer: Callable,
         optimizer_args: dict[str, Any],
-        opt_params: list[dict[str, ArrayLike]],
+        opt_params: list[dict[str, Array]],
     ):
         """Create the optimizers.
 
@@ -57,7 +57,7 @@ class TypeOptimizer:
             optimizer = self.base_optimizer(optimizer_args[name])
             self.optimizers.append({name: optimizer})
 
-    def init(self, opt_params: list[dict[str, ArrayLike]]) -> list:
+    def init(self, opt_params: list[dict[str, Array]]) -> list:
         """Initialize the optimizers. Equivalent to `optax.optimizers.init()`."""
         opt_states = []
         for params, optimizer in zip(opt_params, self.optimizers):
@@ -66,7 +66,7 @@ class TypeOptimizer:
             opt_states.append(opt_state)
         return opt_states
 
-    def update(self, gradient: ArrayLike, opt_state: list) -> tuple[list, list]:
+    def update(self, gradient: Array, opt_state: list) -> tuple[list, list]:
         """Update the optimizers. Equivalent to `optax.optimizers.update()`."""
         all_updates = []
         new_opt_states = []

--- a/jaxley/optimize/optimizer.py
+++ b/jaxley/optimize/optimizer.py
@@ -1,9 +1,10 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+from collections.abc import Callable
+from typing import Any
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
-
-import jax.numpy as jnp
+from jax import Array
+from jax.typing import ArrayLike
 
 
 class TypeOptimizer:
@@ -12,8 +13,8 @@ class TypeOptimizer:
     def __init__(
         self,
         optimizer: Callable,
-        optimizer_args: Dict[str, Any],
-        opt_params: List[Dict[str, jnp.ndarray]],
+        optimizer_args: dict[str, Any],
+        opt_params: list[dict[str, ArrayLike]],
     ):
         """Create the optimizers.
 
@@ -56,7 +57,7 @@ class TypeOptimizer:
             optimizer = self.base_optimizer(optimizer_args[name])
             self.optimizers.append({name: optimizer})
 
-    def init(self, opt_params: List[Dict[str, jnp.ndarray]]) -> List:
+    def init(self, opt_params: list[dict[str, ArrayLike]]) -> list:
         """Initialize the optimizers. Equivalent to `optax.optimizers.init()`."""
         opt_states = []
         for params, optimizer in zip(opt_params, self.optimizers):
@@ -65,7 +66,7 @@ class TypeOptimizer:
             opt_states.append(opt_state)
         return opt_states
 
-    def update(self, gradient: jnp.ndarray, opt_state: List) -> Tuple[List, List]:
+    def update(self, gradient: ArrayLike, opt_state: list) -> tuple[list, list]:
         """Update the optimizers. Equivalent to `optax.optimizers.update()`."""
         all_updates = []
         new_opt_states = []

--- a/jaxley/optimize/transforms.py
+++ b/jaxley/optimize/transforms.py
@@ -1,6 +1,5 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Sequence
 
@@ -193,9 +192,7 @@ class ParamTransform:
 
         self.tf_dict = tf_dict
 
-    def forward(
-        self, params: List[Dict[str, ArrayLike]] | ArrayLike
-    ) -> Dict[str, Array]:
+    def forward(self, params: List[Dict[str, Array]] | Array) -> Dict[str, Array]:
         """Pushes unconstrained parameters through a tf such that they fit the interval.
 
         Args:
@@ -208,9 +205,7 @@ class ParamTransform:
 
         return jax.tree_util.tree_map(lambda x, tf: tf.forward(x), params, self.tf_dict)
 
-    def inverse(
-        self, params: List[Dict[str, ArrayLike]] | ArrayLike
-    ) -> Dict[str, Array]:
+    def inverse(self, params: List[Dict[str, Array]] | Array) -> Dict[str, Array]:
         """Takes parameters from within the interval and makes them unconstrained.
 
         Args:

--- a/jaxley/pumps/ca_pump.py
+++ b/jaxley/pumps/ca_pump.py
@@ -2,6 +2,7 @@
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
 
+from jax import Array
 from jax.typing import ArrayLike
 
 from jaxley.pumps.pump import Pump
@@ -28,19 +29,19 @@ class CaPump(Pump):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update states if necessary (but this pump has no states to update)."""
         return {"CaCon_i": states["CaCon_i"], "i_Ca": states["i_Ca"]}
 
     def compute_current(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         modified_state,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Return change of calcium concentration based on calcium current and decay."""
         prefix = self._name

--- a/jaxley/pumps/ca_pump.py
+++ b/jaxley/pumps/ca_pump.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
+
 from jax.typing import ArrayLike
 
 from jaxley.pumps.pump import Pump

--- a/jaxley/pumps/ca_pump.py
+++ b/jaxley/pumps/ca_pump.py
@@ -1,9 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Dict, Optional
-
-import jax.numpy as jnp
+from typing import Optional
+from jax.typing import ArrayLike
 
 from jaxley.pumps.pump import Pump
 
@@ -29,19 +27,19 @@ class CaPump(Pump):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update states if necessary (but this pump has no states to update)."""
         return {"CaCon_i": states["CaCon_i"], "i_Ca": states["i_Ca"]}
 
     def compute_current(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         modified_state,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Return change of calcium concentration based on calcium current and decay."""
         prefix = self._name
@@ -73,9 +71,9 @@ class CaPump(Pump):
 
     def init_state(
         self,
-        states: Dict[str, jnp.ndarray],
-        v: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
+        v: ArrayLike,
+        params: dict[str, ArrayLike],
         delta_t: float,
     ):
         """Initialize states of channel."""

--- a/jaxley/pumps/faraday_electrolysis.py
+++ b/jaxley/pumps/faraday_electrolysis.py
@@ -2,6 +2,7 @@
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
 
+from jax import Array
 from jax.typing import ArrayLike
 
 from jaxley.pumps.pump import Pump
@@ -105,19 +106,19 @@ class CaFaradayConcentrationChange(Pump):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update states if necessary (but this mechanism has no states to update)."""
         return {"CaCon_i": states["CaCon_i"], "i_Ca": states["i_Ca"]}
 
     def compute_current(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         modified_state,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Return change of calcium concentration as the calcium current."""
         # 2.0 is valence of calcium.

--- a/jaxley/pumps/faraday_electrolysis.py
+++ b/jaxley/pumps/faraday_electrolysis.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
+
 from jax.typing import ArrayLike
 
 from jaxley.pumps.pump import Pump

--- a/jaxley/pumps/faraday_electrolysis.py
+++ b/jaxley/pumps/faraday_electrolysis.py
@@ -1,9 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Dict, Optional
-
-import jax.numpy as jnp
+from typing import Optional
+from jax.typing import ArrayLike
 
 from jaxley.pumps.pump import Pump
 
@@ -106,19 +104,19 @@ class CaFaradayConcentrationChange(Pump):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update states if necessary (but this mechanism has no states to update)."""
         return {"CaCon_i": states["CaCon_i"], "i_Ca": states["i_Ca"]}
 
     def compute_current(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         modified_state,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Return change of calcium concentration as the calcium current."""
         # 2.0 is valence of calcium.
@@ -126,9 +124,9 @@ class CaFaradayConcentrationChange(Pump):
 
     def init_state(
         self,
-        states: Dict[str, jnp.ndarray],
-        v: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
+        v: ArrayLike,
+        params: dict[str, ArrayLike],
         delta_t: float,
     ):
         """Initialize states of channel."""

--- a/jaxley/pumps/pump.py
+++ b/jaxley/pumps/pump.py
@@ -1,9 +1,9 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Tuple
 
+from jax import Array
 from jax.typing import ArrayLike
 
 
@@ -14,8 +14,8 @@ class Pump:
     """
 
     _name: str
-    channel_params: dict[str, ArrayLike]
-    channel_states: dict[str, ArrayLike]
+    channel_params: dict[str, Array]
+    channel_states: dict[str, Array]
     current_name: str
 
     def __init__(self, name: Optional[str] = None):
@@ -59,13 +59,13 @@ class Pump:
         return self
 
     def update_states(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
+        self, states: dict[str, Array], v, params: dict[str, Array]
     ) -> None:
         """Update the states of the pump."""
         raise NotImplementedError
 
     def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
+        self, states: dict[str, Array], v, params: dict[str, Array]
     ) -> None:
         """Given channel states and voltage, return the change in ion concentration.
 

--- a/jaxley/pumps/pump.py
+++ b/jaxley/pumps/pump.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Tuple
 
-import jax.numpy as jnp
+from jax.typing import ArrayLike
 
 
 class Pump:
@@ -13,10 +13,10 @@ class Pump:
     A pump in Jaxley is everything that modifies the intracellular ion concentrations.
     """
 
-    _name = None
-    channel_params = None
-    channel_states = None
-    current_name = None
+    _name: str
+    channel_params: dict[str, ArrayLike]
+    channel_states: dict[str, ArrayLike]
+    current_name: str
 
     def __init__(self, name: Optional[str] = None):
         self._name = name if name else self.__class__.__name__
@@ -59,14 +59,14 @@ class Pump:
         return self
 
     def update_states(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
-    ):
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
+    ) -> None:
         """Update the states of the pump."""
         raise NotImplementedError
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
-    ):
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
+    ) -> None:
         """Given channel states and voltage, return the change in ion concentration.
 
         Args:
@@ -81,9 +81,9 @@ class Pump:
 
     def init_state(
         self,
-        states: Dict[str, jnp.ndarray],
-        v: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
+        v: ArrayLike,
+        params: dict[str, ArrayLike],
         delta_t: float,
     ):
         """Initialize states of channel."""

--- a/jaxley/solver_gate.py
+++ b/jaxley/solver_gate.py
@@ -1,7 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
 import jax.numpy as jnp
+from jax.typing import ArrayLike
 
 
 def save_exp(x, max_value: float = 20.0):
@@ -11,10 +11,10 @@ def save_exp(x, max_value: float = 20.0):
 
 
 def solve_gate_implicit(
-    gating_state: jnp.ndarray,
+    gating_state: ArrayLike,
     dt: float,
-    alpha: jnp.ndarray,
-    beta: jnp.ndarray,
+    alpha: ArrayLike,
+    beta: ArrayLike,
 ):
     a_m = gating_state + dt * alpha
     b_m = 1.0 + dt * alpha + dt * beta
@@ -23,10 +23,10 @@ def solve_gate_implicit(
 
 
 def solve_gate_exponential(
-    x: jnp.ndarray,
+    x: ArrayLike,
     dt: float,
-    alpha: jnp.ndarray,
-    beta: jnp.ndarray,
+    alpha: ArrayLike,
+    beta: ArrayLike,
 ):
     tau = 1 / (alpha + beta)
     xinf = alpha * tau
@@ -34,10 +34,10 @@ def solve_gate_exponential(
 
 
 def exponential_euler(
-    x: jnp.ndarray,
+    x: ArrayLike,
     dt: float,
-    x_inf: jnp.ndarray,
-    x_tau: jnp.ndarray,
+    x_inf: ArrayLike,
+    x_tau: ArrayLike,
 ):
     """An exact solver for the linear dynamical system `dx = -(x - x_inf) / x_tau`."""
     exp_term = save_exp(-dt / x_tau)
@@ -45,19 +45,19 @@ def exponential_euler(
 
 
 def solve_inf_gate_exponential(
-    x: jnp.ndarray,
+    x: ArrayLike,
     dt: float,
-    s_inf: jnp.ndarray,
-    tau_s: jnp.ndarray,
+    s_inf: ArrayLike,
+    tau_s: ArrayLike,
 ):
     """solves dx/dt = (s_inf - x) / tau_s
     via exponential Euler
 
     Args:
-        x (jnp.ndarray): gate variable
+        x (ArrayLike): gate variable
         dt (float): time_delta
-        s_inf (jnp.ndarray): _description_
-        tau_s (jnp.ndarray): _description_
+        s_inf (ArrayLike): _description_
+        tau_s (ArrayLike): _description_
 
     Returns:
         _type_: updated gate

--- a/jaxley/solver_voltage.py
+++ b/jaxley/solver_voltage.py
@@ -1,12 +1,13 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict
 
 import jax.numpy as jnp
 import numpy as np
+from jax import Array
 from jax.experimental.sparse.linalg import spsolve as jax_spsolve
 from jax.lax import fori_loop
+from jax.typing import ArrayLike
 from tridiax.stone import stone_backsub_lower, stone_triang_upper
 
 
@@ -172,13 +173,13 @@ def _comp_based_backsub(index, carry):
 
 
 def _comp_based_backsub_recursive_doubling(
-    diags: jnp.ndarray,
-    solves: jnp.ndarray,
-    lowers: jnp.ndarray,
+    diags: ArrayLike,
+    solves: ArrayLike,
+    lowers: ArrayLike,
     steps: int,
     n_nodes: int,
     parent_lookup: np.ndarray,
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+) -> tuple[Array, Array]:
     """Backsubstitute with recursive doubling.
 
     This function contains a lot of math, so I will describe what is going on here:
@@ -294,15 +295,15 @@ def step_voltage_implicit_with_jax_spsolve(
 
 
 def step_voltage_explicit(
-    voltages: jnp.ndarray,
-    voltage_terms: jnp.ndarray,
-    constant_terms: jnp.ndarray,
-    axial_conductances: jnp.ndarray,
+    voltages: ArrayLike,
+    voltage_terms: ArrayLike,
+    constant_terms: ArrayLike,
+    axial_conductances: ArrayLike,
     sinks,
     sources,
     types,
     delta_t: float,
-) -> jnp.ndarray:
+) -> Array:
     """Solve one timestep of branched nerve equations with explicit (forward) Euler."""
     update = _voltage_vectorfield(
         voltages,
@@ -318,14 +319,14 @@ def step_voltage_explicit(
 
 
 def _voltage_vectorfield(
-    voltages: jnp.ndarray,
-    voltage_terms: jnp.ndarray,
-    constant_terms: jnp.ndarray,
-    axial_conductances: jnp.ndarray,
+    voltages: ArrayLike,
+    voltage_terms: ArrayLike,
+    constant_terms: ArrayLike,
+    axial_conductances: ArrayLike,
     sinks,
     sources,
     types,
-) -> jnp.ndarray:
+) -> Array:
     """Evaluate the vectorfield of the nerve equation."""
     if np.sum(np.isin(types, [1, 2, 3, 4])) > 0:
         raise NotImplementedError(
@@ -345,15 +346,15 @@ def _voltage_vectorfield(
 
 
 def step_voltage_implicit_with_stone(
-    voltages: jnp.ndarray,
-    voltage_terms: jnp.ndarray,
-    constant_terms: jnp.ndarray,
-    axial_conductances: jnp.ndarray,
-    internal_node_inds: jnp.ndarray,
+    voltages: ArrayLike,
+    voltage_terms: ArrayLike,
+    constant_terms: ArrayLike,
+    axial_conductances: ArrayLike,
+    internal_node_inds: ArrayLike,
     n_nodes: int,
-    sinks: jnp.ndarray,
-    sources: jnp.ndarray,
-    types: jnp.ndarray,
+    sinks: ArrayLike,
+    sources: ArrayLike,
+    types: ArrayLike,
     delta_t: float,
 ):
     """Solve one timestep of branched nerve equations with implicit (backward) Euler."""

--- a/jaxley/synapses/synapse.py
+++ b/jaxley/synapses/synapse.py
@@ -1,9 +1,8 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Dict, Optional, Tuple
-
-import jax.numpy as jnp
+from typing import Optional
+from jax import Array
+from jax.typing import ArrayLike
 
 
 class Synapse:
@@ -58,12 +57,12 @@ class Synapse:
         return self
 
     def update_states(
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         delta_t: float,
-        pre_voltage: jnp.ndarray,
-        post_voltage: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
-    ) -> Dict[str, jnp.ndarray]:
+        pre_voltage: ArrayLike,
+        post_voltage: ArrayLike,
+        params: dict[str, ArrayLike],
+    ) -> dict[str, Array]:
         """ODE update step.
 
         Args:
@@ -78,11 +77,11 @@ class Synapse:
         raise NotImplementedError
 
     def compute_current(
-        states: Dict[str, jnp.ndarray],
-        pre_voltage: jnp.ndarray,
-        post_voltage: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
-    ) -> jnp.ndarray:
+        states: dict[str, ArrayLike],
+        pre_voltage: ArrayLike,
+        post_voltage: ArrayLike,
+        params: dict[str, ArrayLike],
+    ) -> Array:
         """Return current through one synapse in `nA`.
 
         Internally, we use `jax.vmap` to vectorize this function across many synapses.

--- a/jaxley/synapses/synapse.py
+++ b/jaxley/synapses/synapse.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
+
 from jax import Array
 from jax.typing import ArrayLike
 

--- a/jaxley/synapses/synapse.py
+++ b/jaxley/synapses/synapse.py
@@ -58,11 +58,11 @@ class Synapse:
         return self
 
     def update_states(
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         delta_t: float,
         pre_voltage: ArrayLike,
         post_voltage: ArrayLike,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ) -> dict[str, Array]:
         """ODE update step.
 
@@ -78,10 +78,10 @@ class Synapse:
         raise NotImplementedError
 
     def compute_current(
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         pre_voltage: ArrayLike,
         post_voltage: ArrayLike,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ) -> Array:
         """Return current through one synapse in `nA`.
 

--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -1,13 +1,11 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from math import pi
-from typing import Callable, Dict, List, Optional, Tuple
-
+from typing import List
 import jax.numpy as jnp
 import numpy as np
 import pandas as pd
-from jax import vmap
+from jax import Array, vmap
+from jax.typing import ArrayLike
 
 from jaxley.utils.misc_utils import cumsum_leading_zero
 
@@ -24,7 +22,7 @@ def equal_segments(branch_property: list, ncomp_per_branch: int):
 
 
 def linear_segments(
-    initial_val: float, endpoint_vals: list, parents: jnp.ndarray, ncomp_per_branch: int
+    initial_val: float, endpoint_vals: list, parents: ArrayLike, ncomp_per_branch: int
 ):
     """Generates segments where some property is linearly interpolated.
 
@@ -153,7 +151,7 @@ def _compute_index_of_child(parents):
     return index_of_child
 
 
-def compute_children_indices(parents) -> List[jnp.ndarray]:
+def compute_children_indices(parents) -> list[Array]:
     """Return all children indices of every branch.
 
     Example:
@@ -170,7 +168,7 @@ def compute_children_indices(parents) -> List[jnp.ndarray]:
 
 
 def get_num_neighbours(
-    num_children: jnp.ndarray,
+    num_children: ArrayLike,
     ncomp_per_branch: int,
     num_branches: int,
 ):
@@ -245,8 +243,8 @@ def interpolate_xyzr(loc: float, coords: np.ndarray):
 
 
 def params_to_pstate(
-    params: List[Dict[str, jnp.ndarray]],
-    indices_set_by_trainables: List[jnp.ndarray],
+    params: list[dict[str, ArrayLike]],
+    indices_set_by_trainables: list[ArrayLike],
 ):
     """Make outputs `get_parameters()` conform with outputs of `.data_set()`.
 
@@ -262,8 +260,8 @@ def params_to_pstate(
 
 
 def convert_point_process_to_distributed(
-    current: jnp.ndarray, area: jnp.ndarray
-) -> jnp.ndarray:
+    current: ArrayLike, area: ArrayLike
+) -> Array:
     """Convert current point process (nA) to distributed current (uA/cm2).
 
     This function gets called for synapses and for external stimuli.
@@ -296,7 +294,7 @@ def query_channel_states_and_params(d, keys, idcs):
 
 def compute_children_and_parents(
     branch_edges: pd.DataFrame,
-) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, int]:
+) -> tuple[Array, Array, Array, int]:
     """Build indices used during `._init_morph_custom_spsolve()."""
     par_inds = branch_edges["parent_branch_index"].to_numpy()
     child_inds = branch_edges["child_branch_index"].to_numpy()

--- a/jaxley/utils/cell_utils.py
+++ b/jaxley/utils/cell_utils.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import List
+
 import jax.numpy as jnp
 import numpy as np
 import pandas as pd
@@ -259,9 +260,7 @@ def params_to_pstate(
     ]
 
 
-def convert_point_process_to_distributed(
-    current: ArrayLike, area: ArrayLike
-) -> Array:
+def convert_point_process_to_distributed(current: ArrayLike, area: ArrayLike) -> Array:
     """Convert current point process (nA) to distributed current (uA/cm2).
 
     This function gets called for synapses and for external stimuli.

--- a/jaxley/utils/debug_solver.py
+++ b/jaxley/utils/debug_solver.py
@@ -1,10 +1,8 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Tuple
-
 import jax.numpy as jnp
-import numpy as np
+from jax import Array
+from jax.typing import ArrayLike
 
 
 def compute_morphology_indices(
@@ -162,10 +160,9 @@ def build_voltage_matrix_elements(
 
 
 def drop_ncomp_th_element(
-    arr: jnp.ndarray, ncomp: int, nbranches: int, start: int
-) -> jnp.ndarray:
-    """
-    Create an array of integers from 0 to limit, dropping every n-th element.
+    arr: ArrayLike, ncomp: int, nbranches: int, start: int
+) -> Array:
+    """Create an array of integers from 0 to limit, dropping every n-th element.
 
     Written by ChatGPT.
 

--- a/jaxley/utils/jax_utils.py
+++ b/jaxley/utils/jax_utils.py
@@ -1,12 +1,11 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
 import math
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, TypeVar
 
 import jax
 import jax.numpy as jnp
-import pandas as pd
+from jax.typing import ArrayLike
 
 Carry = TypeVar("Carry")
 Input = TypeVar("Input")
@@ -15,10 +14,10 @@ Func = TypeVar("Func", bound=Callable)
 
 
 def nested_checkpoint_scan(
-    f: Callable[[Carry, Dict[str, jnp.ndarray]], Tuple[Carry, Output]],
+    f: Callable[[Carry, dict[str, ArrayLike]], tuple[Carry, Output]],
     init: Carry,
-    xs: Dict[str, jnp.ndarray],
-    length: Optional[int] = None,
+    xs: dict[str, ArrayLike],
+    length: int | None = None,
     *,
     nested_lengths: Sequence[int],
     scan_fn=jax.lax.scan,

--- a/jaxley/utils/morph_attributes.py
+++ b/jaxley/utils/morph_attributes.py
@@ -1,11 +1,11 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Callable, Dict, List, Optional, Tuple
-
+from typing import List, Optional
 import jax.numpy as jnp
 import numpy as np
 import pandas as pd
+from jax import Array
+from jax.typing import ArrayLike
 
 
 def morph_attrs_from_xyzr(
@@ -254,7 +254,7 @@ def swc_resistive_load(lengths: np.ndarray, radii: np.ndarray) -> np.ndarray:
     return np.sum(segment_integrals) / jnp.pi
 
 
-def cylinder_area(length: jnp.ndarray, radius: jnp.ndarray) -> jnp.ndarray:
+def cylinder_area(length: ArrayLike, radius: ArrayLike) -> Array:
     r"""Return the surface area of a cylindric compartment, given its length and radius.
 
     Args:
@@ -266,7 +266,7 @@ def cylinder_area(length: jnp.ndarray, radius: jnp.ndarray) -> jnp.ndarray:
     return 2.0 * jnp.pi * radius * length
 
 
-def cylinder_volume(length: jnp.ndarray, radius: jnp.ndarray) -> jnp.ndarray:
+def cylinder_volume(length: ArrayLike, radius: ArrayLike) -> Array:
     r"""Return the volume of a cylindric compartment, given its length and radius.
 
     The resistive load is defined as the integral over :math:`1/(\pi r^2)`, i.e.,
@@ -287,7 +287,7 @@ def cylinder_volume(length: jnp.ndarray, radius: jnp.ndarray) -> jnp.ndarray:
     return length * radius**2 * jnp.pi
 
 
-def cylinder_resistive_load(length: jnp.ndarray, radius: jnp.ndarray) -> jnp.ndarray:
+def cylinder_resistive_load(length: ArrayLike, radius: ArrayLike) -> Array:
     r"""Return the resistive load of a cylindric compartment, given length and radius.
 
     The resistive load is defined as the integral over :math:`1/(\pi r^2)`, i.e.,
@@ -310,9 +310,9 @@ def cylinder_resistive_load(length: jnp.ndarray, radius: jnp.ndarray) -> jnp.nda
 
 def compute_axial_conductances(
     comp_edges: pd.DataFrame,
-    params: Dict[str, jnp.ndarray],
-    diffusion_states: List[str],
-) -> Dict[str, jnp.ndarray]:
+    params: dict[str, ArrayLike],
+    diffusion_states: list[str],
+) -> dict[str, Array]:
     r"""Given `comp_edges`, radius, length, r_a, cm, compute the axial conductances.
 
     Note that the resulting axial conductances will already by divided by the

--- a/jaxley/utils/morph_attributes.py
+++ b/jaxley/utils/morph_attributes.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import List, Optional
+
 import jax.numpy as jnp
 import numpy as np
 import pandas as pd

--- a/jaxley/utils/morph_attributes.py
+++ b/jaxley/utils/morph_attributes.py
@@ -311,7 +311,7 @@ def cylinder_resistive_load(length: ArrayLike, radius: ArrayLike) -> Array:
 
 def compute_axial_conductances(
     comp_edges: pd.DataFrame,
-    params: dict[str, ArrayLike],
+    params: dict[str, Array],
     diffusion_states: list[str],
 ) -> dict[str, Array]:
     r"""Given `comp_edges`, radius, length, r_a, cm, compute the axial conductances.

--- a/jaxley/utils/solver_utils.py
+++ b/jaxley/utils/solver_utils.py
@@ -1,12 +1,12 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple
 
 import jax.numpy as jnp
 import networkx as nx
 import numpy as np
 import pandas as pd
+from jax import Array
 
 
 def convert_to_csc(
@@ -44,7 +44,7 @@ def convert_to_csc(
 
 def comp_edges_to_indices(
     comp_edges: pd.DataFrame,
-) -> Tuple[int, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+) -> tuple[int, Array, Array, Array]:
     """Generates sparse matrix indices from the table of node edges.
 
     This is only used for the `jax.sparse` voltage solver.

--- a/jaxley/utils/syn_utils.py
+++ b/jaxley/utils/syn_utils.py
@@ -1,19 +1,18 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Tuple
-
 import jax.numpy as jnp
 import numpy as np
+from jax import Array
 from jax.lax import ScatterDimensionNumbers, scatter_add
+from jax.typing import ArrayLike
 
 
 def gather_synapes(
-    number_of_compartments: jnp.ndarray,
+    number_of_compartments: ArrayLike,
     post_syn_comp_inds: np.ndarray,
-    current_each_synapse_voltage_term: jnp.ndarray,
-    current_each_synapse_constant_term: jnp.ndarray,
-) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    current_each_synapse_voltage_term: ArrayLike,
+    current_each_synapse_constant_term: ArrayLike,
+) -> tuple[Array, Array]:
     """Compute current at the post synapse.
 
     All this does it that it sums the synaptic currents that come into a particular

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 import jax
+from jax import Array
 from jax.typing import ArrayLike
 
 jax.config.update("jax_enable_x64", True)
@@ -223,10 +224,10 @@ class KCA11(Channel):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update state."""
         prefix = self._name
@@ -238,9 +239,7 @@ class KCA11(Channel):
         new_m = solve_inf_gate_exponential(m, dt, *self.m_gate(v, cai, q10))
         return {f"{prefix}_m": new_m}
 
-    def compute_current(
-        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
-    ):
+    def compute_current(self, states: dict[str, Array], v, params: dict[str, Array]):
         """Return current."""
         prefix = self._name
         m = states[f"{prefix}_m"]

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,7 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
 import jax
+from jax.typing import ArrayLike
 
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_platform_name", "cpu")
@@ -223,10 +223,10 @@ class KCA11(Channel):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update state."""
         prefix = self._name
@@ -239,7 +239,7 @@ class KCA11(Channel):
         return {f"{prefix}_m": new_m}
 
     def compute_current(
-        self, states: Dict[str, jnp.ndarray], v, params: Dict[str, jnp.ndarray]
+        self, states: dict[str, ArrayLike], v, params: dict[str, ArrayLike]
     ):
         """Return current."""
         prefix = self._name

--- a/tests/test_ion_diffusion_and_pumps.py
+++ b/tests/test_ion_diffusion_and_pumps.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import jax
 import pytest
+from jax import Array
 from jax.typing import ArrayLike
 
 jax.config.update("jax_enable_x64", True)
@@ -44,19 +45,19 @@ class NaPump(Pump):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update states if necessary (but this pump has no states to update)."""
         return {"NaCon_i": states["NaCon_i"], "i_Na": states["i_Na"]}
 
     def compute_current(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         modified_state,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Return change of calcium concentration based on calcium current and decay."""
         prefix = self._name
@@ -150,19 +151,19 @@ class CaPump2(Pump):
 
     def update_states(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         dt,
         v,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update states if necessary (but this pump has no states to update)."""
         return {"CaCon_i": states["CaCon_i"], "i_Ca": states["i_Ca"]}
 
     def compute_current(
         self,
-        states: dict[str, ArrayLike],
+        states: dict[str, Array],
         modified_state,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Return change of calcium concentration based on calcium current and decay."""
         prefix = self._name

--- a/tests/test_ion_diffusion_and_pumps.py
+++ b/tests/test_ion_diffusion_and_pumps.py
@@ -1,5 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
+from typing import Optional
+
 import jax
 import pytest
 from jax.typing import ArrayLike

--- a/tests/test_ion_diffusion_and_pumps.py
+++ b/tests/test_ion_diffusion_and_pumps.py
@@ -1,11 +1,8 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from copy import deepcopy
-from typing import Dict, Optional
-
 import jax
 import pytest
+from jax.typing import ArrayLike
 
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_platform_name", "cpu")
@@ -45,19 +42,19 @@ class NaPump(Pump):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update states if necessary (but this pump has no states to update)."""
         return {"NaCon_i": states["NaCon_i"], "i_Na": states["i_Na"]}
 
     def compute_current(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         modified_state,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Return change of calcium concentration based on calcium current and decay."""
         prefix = self._name
@@ -77,9 +74,9 @@ class NaPump(Pump):
 
     def init_state(
         self,
-        states: Dict[str, jnp.ndarray],
-        v: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
+        v: ArrayLike,
+        params: dict[str, ArrayLike],
         delta_t: float,
     ):
         """Initialize states of channel."""
@@ -151,19 +148,19 @@ class CaPump2(Pump):
 
     def update_states(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         dt,
         v,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update states if necessary (but this pump has no states to update)."""
         return {"CaCon_i": states["CaCon_i"], "i_Ca": states["i_Ca"]}
 
     def compute_current(
         self,
-        states: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
         modified_state,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Return change of calcium concentration based on calcium current and decay."""
         prefix = self._name
@@ -183,9 +180,9 @@ class CaPump2(Pump):
 
     def init_state(
         self,
-        states: Dict[str, jnp.ndarray],
-        v: jnp.ndarray,
-        params: Dict[str, jnp.ndarray],
+        states: dict[str, ArrayLike],
+        v: ArrayLike,
+        params: dict[str, ArrayLike],
         delta_t: float,
     ):
         """Initialize states of channel."""

--- a/tests/test_shared_state.py
+++ b/tests/test_shared_state.py
@@ -1,6 +1,7 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from typing import Optional
+
 import jax
 from jax.typing import ArrayLike
 

--- a/tests/test_shared_state.py
+++ b/tests/test_shared_state.py
@@ -3,6 +3,7 @@
 from typing import Optional
 
 import jax
+from jax import Array
 from jax.typing import ArrayLike
 
 jax.config.update("jax_enable_x64", True)
@@ -87,7 +88,7 @@ class CaHVA(Channel):
         u: dict[str, ArrayLike],
         dt: float,
         voltages: float,
-        params: dict[str, ArrayLike],
+        params: dict[str, Array],
     ):
         """Update state of gating variables."""
         prefix = self._name

--- a/tests/test_shared_state.py
+++ b/tests/test_shared_state.py
@@ -1,9 +1,8 @@
 # This file is part of Jaxley, a differentiable neuroscience simulator. Jaxley is
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
-
-from typing import Dict, Optional
-
+from typing import Optional
 import jax
+from jax.typing import ArrayLike
 
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_platform_name", "cpu")
@@ -84,10 +83,10 @@ class CaHVA(Channel):
 
     def update_states(
         self,
-        u: Dict[str, jnp.ndarray],
+        u: dict[str, ArrayLike],
         dt: float,
         voltages: float,
-        params: Dict[str, jnp.ndarray],
+        params: dict[str, ArrayLike],
     ):
         """Update state of gating variables."""
         prefix = self._name
@@ -97,7 +96,7 @@ class CaHVA(Channel):
         return {f"{prefix}_m": m_new, f"{prefix}_h": h_new, "eCa": u["eCa"]}
 
     def compute_current(
-        self, u: Dict[str, jnp.ndarray], voltages, params: Dict[str, jnp.ndarray]
+        self, u: dict[str, ArrayLike], voltages, params: dict[str, ArrayLike]
     ):
         """Compute the current through the channel."""
         prefix = self._name


### PR DESCRIPTION
Fixes/implements #469 

Note that additional non-jax typing changed were made, however these changes were only made on the same lines where the jax related typing changes were made. The changes are mostly using Python native types (list, dict, tuple, etc.) instead of types from the typing package (List, Dict, Tuple, etc.). Using Python native types has been standard since Python 3.9, so I hope these additional changes are also okay, since Jaxley claims to require Python>=3.10 anyway. 