### PR TITLE
Carry over groups from constituents of a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - fix for networks that mix point neurons and morphologically detailed neurons (#702,
 @michaeldeistler)
+- carry over groups from constituents of a module (e.g., `jx.Cell` groups get carried
+over to `jx.Network`) (#703, @michaeldeistler)
 
 
 # 0.11.2

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -840,6 +840,12 @@ class Module(ABC):
             name = channel._name
             self.base.nodes.loc[self.nodes[name].isna(), name] = False
 
+        # Set columns of groups to `False` instead of `NaN`.
+        for name in self.base.group_names:
+            self.base.nodes.loc[self.nodes[name].isna(), name] = False
+            # Ensure that type is boolean---in some cases, it had been an `object`.
+            self.base.nodes[name] = self.base.nodes[name].astype(bool)
+
     @only_allow_module
     def to_jax(self):
         # TODO FROM #447: Make this work for View?

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -136,3 +136,17 @@ def test_set_ncomp_changes_groups(SimpleCell):
     cell.branch(1).add_to_group("exc")
     cell.branch(0).set_ncomp(2)
     assert len(cell.exc.nodes) == 6  # 2 from branch(0) and 4 from branch(1).
+
+
+def test_groups_are_carried_over_from_constituents(SimpleCell):
+    cell1 = SimpleCell(2, 3)
+    cell1.set("radius", np.arange(6))
+    cell1.branch(1).add_to_group("soma")
+
+    cell2 = SimpleCell(2, 3)
+    cell2.set("radius", 10 * np.arange(6))
+    cell2.branch(0).add_to_group("axon")
+
+    net = jx.Network([cell1, cell2])
+    assert (net.soma.nodes["radius"].values == cell1.soma.nodes["radius"].values).all()
+    assert (net.axon.nodes["radius"].values == cell2.axon.nodes["radius"].values).all()


### PR DESCRIPTION
Fixup for things like:
```python
cell1 = jx.Cell()
cell1.add_to_group("soma")

cell2 = jx.Cell()
cell2.add_to_group("axon")

net = jx.Network([cell1, cell2])
net.soma
```
