### PR TITLE
Bugfix for indexing in `init_states` for networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 0.11.4 (pre-release)
 
+### 🐛 Bug fixes
+
+- bugfix for indexing when `init_states()` is run on a `jx.Network` (#711,
+@michaeldeistler)
+
 ### 📚 Documentation
 
 - add an example on fitting a morphologically detailed cell with gradient descent (#705,

--- a/jaxley/modules/base.py
+++ b/jaxley/modules/base.py
@@ -1841,9 +1841,7 @@ class Module(ABC):
 
         for channel in self.base.channels + self.base.pumps:
             name = channel._name
-            channel_indices = channel_nodes.loc[channel_nodes[name]][
-                "global_comp_index"
-            ].to_numpy()
+            channel_indices = channel_nodes.loc[channel_nodes[name]].index.to_numpy()
             voltages = channel_nodes.loc[channel_indices, "v"].to_numpy()
 
             channel_param_names = list(channel.channel_params.keys())


### PR DESCRIPTION
To reproduce the error:

```python
from jaxley.channels import HH

comp = jx.Compartment()
branch = jx.Branch(comp, ncomp=2)
cell1 = jx.Cell(branch, [-1, 0, 1])
cell2 = jx.Cell(branch, [-1, 0, 1, 2])
cell3 = jx.Cell(branch, [-1, 0])
net = jx.Network([cell1, cell2, cell3])

net.cell(0).branch(1).add_to_group("apical")
net.cell(1).branch(3).add_to_group("apical")
net.cell(2).branch(1).add_to_group("apical")

net.apical.insert(HH())

net.init_states()
```

The reason that this bug happened is that `init_states` was still using the `global_comp_index`, instead of the `index` (as is done in `step_channels`).