### PR TITLE
separate currents from `get_all_states()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 0.11.6 (pre-release)
 
+### 🛠️ Internal updates
+
+-  separate getting the currents from `get_all_states()` (#727, @michaeldeistler). To
+restore the previous behaviour, do:
+```python
+states = cell.get_all_states(pstate)
+states = cell.append_channel_currents_to_states(states, all_params, delta_t)
+```
+
 ### 🐛 Bug fixes
 
 - bugfix for `cell.vis(..., type="morph")` (#725, @michaeldeistler, thanks to

--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -124,11 +124,11 @@ def build_init_and_step_fn(
             pstate += param_state
 
         all_params = module.get_all_parameters(pstate)
-        all_states = (
-            module.get_all_states(pstate, all_params, delta_t)
-            if all_states is None
-            else all_states
-        )
+        if all_states is None:
+            all_states = module.get_all_states(pstate)
+            all_states = module.append_channel_currents_to_states(
+                all_states, all_params, delta_t
+            )
         return all_states, all_params
 
     def step_fn(


### PR DESCRIPTION
In discussion with @Matthijspals, we found that this PR makes #719 easier to implement. I also think that separating this logic is nice and clearer.