### PR TITLE
feat: modify post-synaptic states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 - `Fire` channels now implement a surrogate gradient (#735, @alexpejovic)
 - New `SpikeSynapse` added, which detects `Fire` channel spikes (#735, @alexpejovic)
-- Enable synapses to modify any post-synaptic state, not just voltage ().
+- Enable synapses to modify any post-synaptic state, not just voltage (#755,
+@michaeldeistler).
 
 ### 📚 Documentation
 


### PR DESCRIPTION
This PR enables to have synapses that modify _any_ post-synaptic state. Thus, the `StateSynapse` is the synaptic equivalent to the `Pump`.

EDIT: I don't think we should merge this for now. We could of course have something like the pump: a synapse that modifies **one** post-synaptic state. But what if the user wants to modify multiple such states? Then our pump solution would no longer work. Since we do not have _any_ concrete example of what we would like to achieve, I am somewhat hesitant to just decide on an API. In addition, this is something we can always add _on top_, and it can just be a new feature in the future --- not necessarily for v1.0.