### PR TITLE
doc: Improve examples in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.0.0 (pre-release)
+
+### 📚 Documentation
+
+- Improved examples in documentation (#759, @michaeldeistler)
+- Manually remove some functions from the documentation (#759, @michaeldeistler)
+
+
 # 0.12.0
 
 ### 🧩 New features

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -6,3 +6,4 @@
    :undoc-members:
    :inherited-members:
    :show-inheritance:
+   :exclude-members: get_all_states, get_all_parameters, append_channel_currents_to_states


### PR DESCRIPTION
Rename some functions to make the docs slimmer:
```text
get_all_parameters -> _get_all_parameters
get_all_states -> _get_all_states
append_channel_currents_to_states -> _append_channel_currents_to_states
```

In addition, it improves examples in documentation.