### PR TITLE
Make _remove_currents_from_states copy states instead of editing in-place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add an identity transformation (`jaxley.optimize.transforms.IdentityTransform`) (#777, @chaseking)
 
+### 🐛 Bug fixes
+
+- Fix issue where `build_dynamic_state_utils` `remove_observables` performed in-place deletions on full state dict (#775, @chaseking)
+
 
 # 0.13.0
 

--- a/jaxley/utils/dynamics.py
+++ b/jaxley/utils/dynamics.py
@@ -11,7 +11,7 @@ from jax.tree_util import tree_map, tree_map_with_path
 
 
 def _remove_currents_from_states(states: dict[str, Array], current_keys: list[str]):
-    """Copies states without the currents through channels and synapses.
+    """Shallow copy of the states, excluding the currents through channels and synapses.
 
     Args:
         states: States (including currents) of the system.


### PR DESCRIPTION
Corrects in-place update by making copy of states instead (#775)