### PR TITLE
fixed save_exp clipping for compatibility with newest JAX versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Implements Brette et al. (2005), 'Adaptive exponential integrate-and-fire model 
 - Fix issue causing some `View`s to take too long to create (#791, @alexpejovic)
 - Fix single point branch plotting with type="comp" (#797, @jnsbck)
 - jx.integrate took O(n^2) time with n compartments on the backwards pass. Instead of backpropagating through the forward solve, we now use a custom_jvp (another tridiagonal solve, which is O(n)) (#795 @manuelgloeckler)
+- Fix compatibility with newer JAX versions by avoiding the deprecated `jnp.clip(..., a_max=...)` keyword in `solver_gate.save_exp` (#798, @lorenzosquadrani)
 
 # 0.13.0
 

--- a/jaxley/solver_gate.py
+++ b/jaxley/solver_gate.py
@@ -6,7 +6,7 @@ from jax.typing import ArrayLike
 
 def save_exp(x, max_value: float = 20.0):
     """Clip the input to a maximum value and return its exponential."""
-    x = jnp.clip(x, a_max=max_value)
+    x = jnp.minimum(x, max_value)
     return jnp.exp(x)
 
 


### PR DESCRIPTION
Fixes #798

Replaces the deprecated `jnp.clip(..., a_max=...)` usage in `save_exp` with `jnp.minimum`.
I chose to use `jnp.minimum` because it what `jnp.clip` does under the hood when only the `max` argument is provided.
No more keyword arguments, to avoid it to happen again.