### PR TITLE
Vectorized Recordings

### DIFF
--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -393,7 +393,7 @@ def integrate(
     # Function to efficiently gather recorded states from dict of states
     def gather_recs(state: Dict[str, Array]) -> Array:
         """Return all recorded values, using one gather per recorded state."""
-        parts = jnp.array([state[state_name][inds] for state_name, inds in rec_groups])
+        parts = [state[state_name][inds] for state_name, inds in rec_groups]
         recs = parts[0] if len(parts) == 1 else jnp.concatenate(parts)
         return recs if rec_order is None else recs[rec_order]
 
@@ -453,7 +453,6 @@ def integrate(
         assert (
             nsteps_to_return <= length
         ), "The desired simulation duration is longer than `prod(nested_length)`."
-
         if externals:
             for key in externals.keys():
                 dummy_external = jnp.zeros((size_difference, externals[key].shape[1]))

--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -376,7 +376,7 @@ def integrate(
 
     # Group the recordings by state so that each recorded state is read with a
     # single vectorized gather.
-    rec_info = module.rec_info.reset_index(drop=True)
+    rec_info = module.recordings.reset_index(drop=True)
     rec_groups = []
     concat_positions = []
     for state_name, group in rec_info.groupby("state", sort=False):

--- a/jaxley/integrate.py
+++ b/jaxley/integrate.py
@@ -2,9 +2,8 @@
 # licensed under the Apache License Version 2.0, see <https://www.apache.org/licenses/>
 from collections.abc import Callable
 from math import prod
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple
 
-import jax
 import jax.numpy as jnp
 import pandas as pd
 from jax import Array
@@ -374,8 +373,29 @@ def integrate(
 
     if module.recordings.empty:
         raise ValueError("No recordings are set. Please set them.")
-    rec_inds = module.recordings.rec_index.to_numpy()
-    rec_states = module.recordings.state.to_numpy()
+
+    # Group the recordings by state so that each recorded state is read with a
+    # single vectorized gather.
+    rec_info = module.rec_info.reset_index(drop=True)
+    rec_groups = []
+    concat_positions = []
+    for state_name, group in rec_info.groupby("state", sort=False):
+        rec_groups.append((state_name, group["rec_index"].to_numpy()))
+        concat_positions.extend(group.index)
+
+    # Permutation restoring the user's requested recording order once the
+    # per-state gathers are concatenated. Monotonic positions mean concatenating
+    # already yields that order, so no permutation is emitted (the common case of
+    # a single recorded state).
+    positions = pd.Index(concat_positions)
+    rec_order = None if positions.is_monotonic_increasing else positions.argsort()
+
+    # Function to efficiently gather recorded states from dict of states
+    def gather_recs(state: Dict[str, Array]) -> Array:
+        """Return all recorded values, using one gather per recorded state."""
+        parts = jnp.array([state[state_name][inds] for state_name, inds in rec_groups])
+        recs = parts[0] if len(parts) == 1 else jnp.concatenate(parts)
+        return recs if rec_order is None else recs[rec_order]
 
     # Shorten or pad stimulus depending on `t_max`.
     if t_max is not None:
@@ -412,12 +432,7 @@ def integrate(
 
     def _body_fun(state, externals):
         state = step_fn(state, all_params, externals, external_inds, delta_t)
-        recs = jnp.asarray(
-            [
-                state[rec_state][rec_ind]
-                for rec_state, rec_ind in zip(rec_states, rec_inds)
-            ]
-        )
+        recs = gather_recs(state)
         return state, recs
 
     # If necessary, pad the stimulus with zeros in order to simulate sufficiently long.
@@ -438,18 +453,14 @@ def integrate(
         assert (
             nsteps_to_return <= length
         ), "The desired simulation duration is longer than `prod(nested_length)`."
+
         if externals:
             for key in externals.keys():
                 dummy_external = jnp.zeros((size_difference, externals[key].shape[1]))
                 externals[key] = jnp.concatenate([externals[key], dummy_external])
 
     # Record the initial state.
-    init_recs = jnp.asarray(
-        [
-            all_states[rec_state][rec_ind]
-            for rec_state, rec_ind in zip(rec_states, rec_inds)
-        ]
-    )
+    init_recs = gather_recs(all_states)
     init_recording = jnp.expand_dims(init_recs, axis=0)
 
     # Run simulation.


### PR DESCRIPTION
Same as PR #805 but from my side is ready. 

[tmp.py](https://github.com/user-attachments/files/31867032/tmp.py)

Running the above script on an H100 on the this branch gave me

```
Created Network: 12.188806571997702s
Inserted channels: 0.0035030310973525047s
Inserted synapses: 4.91081273695454s
Added stimulus: 4.646241574082524s
Added recording: 4.641703790053725s
Lowering: 28.356287381146103s
Compiling: 0.7313280128873885s
Running: 0.006916529033333063s
```

while on the main branch it returned

```
Created Network: 12.139616114087403s
Inserted channels: 0.003935906104743481s
Inserted synapses: 11.178901250008494s
Added stimulus: 5.253586169797927s
Added recording: 5.075950373895466s
Lowering: 32.77653562184423s
Compiling: 22.02194092888385s
Running: 0.008850491140037775s
```

The compiling time is greatly reduced.
