### PR TITLE
Fix jitting solvers with constant matrices broken under jit(vmap) on certain JAX versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Implements Brette et al. (2005), 'Adaptive exponential integrate-and-fire model 
 - Fix single point branch plotting with type="comp" (#797, @jnsbck)
 - jx.integrate took O(n^2) time with n compartments on the backwards pass. Instead of backpropagating through the forward solve, we now use a custom_jvp (another tridiagonal solve, which is O(n)) (#795 @manuelgloeckler)
 - Fix compatibility with newer JAX versions by avoiding the deprecated `jnp.clip(..., a_max=...)` keyword in `solver_gate.save_exp` (#798, @lorenzosquadrani)
+- Fix incorrect implicit voltage RHS under `jit(vmap)` on jax/jaxlib 0.5.3–0.8.1 by assembling as set-then-add instead of `v[i] + dt * c[i]` (@matthijspals)
 
 # 0.13.0
 

--- a/jaxley/solver_voltage.py
+++ b/jaxley/solver_voltage.py
@@ -186,10 +186,12 @@ def step_voltage_implicit_with_dhs_solve(
     if len(sinks) > 0:
         diags = diags.at[sinks].add(axial_conductances)
 
-    # Build solve.
+    # Build solve. Use set + add (not `v[i] + dt * c[i]`) to avoid an XLA
+    # constant-folding bug under jit(vmap) on jax 0.5.3–0.8.1 (jax#33479).
     solves = jnp.zeros(n_nodes)
-    solves = solves.at[internal_node_inds].set(
-        voltages[internal_node_inds] + delta_t * constant_terms[internal_node_inds]
+    solves = solves.at[internal_node_inds].set(voltages[internal_node_inds])
+    solves = solves.at[internal_node_inds].add(
+        (delta_t * constant_terms)[internal_node_inds]
     )
 
     # Why `n_nodes > 1`? For compartments (or point neurons), we save computation and
@@ -377,8 +379,9 @@ def step_voltage_implicit_with_jax_spsolve(
 
     # Build solve.
     solves = jnp.zeros(n_nodes)
-    solves = solves.at[internal_node_inds].set(
-        voltages[internal_node_inds] + delta_t * constant_terms[internal_node_inds]
+    solves = solves.at[internal_node_inds].set(voltages[internal_node_inds])
+    solves = solves.at[internal_node_inds].add(
+        (delta_t * constant_terms)[internal_node_inds]
     )
 
     # Concatenate diagonals and off-diagonals (which are just `-axial_conductances`).
@@ -547,8 +550,9 @@ def step_voltage_implicit_with_stone(
 
     # Build solve.
     solves = jnp.zeros(n_nodes)
-    solves = solves.at[internal_node_inds].set(
-        voltages[internal_node_inds] + delta_t * constant_terms[internal_node_inds]
+    solves = solves.at[internal_node_inds].set(voltages[internal_node_inds])
+    solves = solves.at[internal_node_inds].add(
+        (delta_t * constant_terms)[internal_node_inds]
     )
 
     # Solve the tridiagonal system.

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -112,3 +112,60 @@ def test_dhs_solve_handles_ragged_grouped_edges(optimize_for_gpu):
     actual_grad = np.asarray(grad_fn(rhs))
     expected_grad = np.linalg.solve(matrix.T, np.ones_like(expected))
     np.testing.assert_allclose(actual_grad, expected_grad, rtol=1e-6, atol=1e-6)
+
+
+def test_dhs_vmap_closed_over_rhs_matches_arg():
+    """``jit(vmap(DHS))`` must agree for argument vs closed-over multi-column RHS.
+
+    On jax/jaxlib in roughly ``[0.5.3, 0.8.1]``, the old RHS form
+    ``v[i] + dt * c[i]`` inside ``step_voltage_implicit_with_dhs_solve`` returned
+    wrong primals when the RHS matrix was a compile-time constant (jax#33479 /
+    xla#34260). This regression guards the scale-before-gather rewrite.
+    """
+    from jaxley.channels import Leak
+    from jaxley.integrate import build_init_and_step_fn
+    from jaxley.solver_voltage import step_voltage_implicit_with_dhs_solve
+
+    branch = jx.Branch(jx.Compartment(), ncomp=4)
+    cell = jx.Cell([branch] * 3, parents=[-1, 0, 0])
+    cell.insert(Leak())
+    cell.to_jax()
+    build_init_and_step_fn(cell, voltage_solver="jaxley.dhs.cpu")
+
+    N = len(cell.nodes)
+    n_nodes = int(cell._n_nodes)
+    dt = 0.025
+    idxr = cell._dhs_solve_indexer
+    internal = cell._internal_node_inds
+    sinks = np.asarray(cell._comp_edges["sink"].to_list())
+    ap = cell.get_all_parameters([])
+    axial = jnp.asarray(ap["axial_conductances"]["v"])
+    g_leak = jnp.asarray(ap["Leak_gLeak"][:N])
+    cm = jnp.asarray(ap["capacitance"][:N])
+    vt = jnp.zeros((n_nodes,)).at[:N].set(g_leak / cm)
+    B = jax.random.normal(jax.random.PRNGKey(0), (N, 8))
+
+    def solve_col(rhs):
+        voltages = jnp.zeros((n_nodes,)).at[:N].set(rhs)
+        out = step_voltage_implicit_with_dhs_solve(
+            voltages,
+            vt,
+            jnp.zeros_like(voltages),
+            axial,
+            internal,
+            sinks,
+            n_nodes,
+            idxr,
+            False,
+            dt,
+        )
+        return out[:N]
+
+    def solve_mat(M):
+        return jax.vmap(solve_col, in_axes=1, out_axes=1)(M)
+
+    eager = solve_mat(B)
+    as_arg = jax.jit(solve_mat)(B)
+    closed = jax.jit(lambda: solve_mat(B))()
+    np.testing.assert_allclose(as_arg, eager, rtol=1e-10, atol=1e-10)
+    np.testing.assert_allclose(closed, eager, rtol=1e-10, atol=1e-10)


### PR DESCRIPTION
Between **jax/jaxlib ≈ 0.5.3 and 0.8.1**, the pattern below (used in the Jaxley solver) seems broken when jitting a `vmap` over several columns of a matrix that is a constant inside the function (i.e., not passed in as an argument):

```python
solves.at[i].set(voltages[i] + delta_t * constant_terms[i])
```

`jit(f)(B)` is fine but `jit(lambda: f(B))()` returns wrong values. See [jax-ml/jax#33479](https://github.com/jax-ml/jax/issues/33479) / [openxla/xla#34260](https://github.com/openxla/xla/issues/34260) (fixed in jaxlib ≥ 0.8.2).

**Minimal example:**
```python
import jax, jax.numpy as jnp

B = jax.random.normal(jax.random.PRNGKey(0), (10, 8))
idx = jnp.array([1, 3, 5, 7])

def col_fn(rhs):
    v = jnp.zeros(10).at[:10].set(rhs)
    c = jnp.zeros(10)
    return jnp.zeros(10).at[idx].set(v[idx] + 0.025 * c[idx])

vmap_fn = lambda M: jax.vmap(col_fn, in_axes=1, out_axes=1)(M)
print(jnp.max(jnp.abs(jax.jit(vmap_fn)(B) - jax.jit(lambda: vmap_fn(B))())))
```

This affects Jaxley’s implicit voltage solves (DHS, sparse, Stone) when applying them to each column of a fixed matrix `B` inside a jitted function.

**Fix:** 
write it as:
```python
solves = solves.at[i].set(voltages[i])
solves = solves.at[i].add((delta_t * constant_terms)[i])
```

**Added a test** that `jit(vmap)(B)` matches `jit(lambda: vmap(B))()`

Disclaimer: diagnosed and fixed with help of cursor.